### PR TITLE
Add configuration mappings and refactor data structures to use IDs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,57 @@
 [sources]
 urls = [
   "https://hessen-tanzt.de/media/ht2024/"
-] 
+]
+
+# Age Group Mappings (German <-> English)
+[age_groups]
+"Hgr" = { id = "adult" }
+"Hgr." = { id = "adult" }
+"Hgr.II" = { id = "adult_2" }
+"Hgr II" = { id = "adult_2" }
+"Sen" = { id = "senior" }
+"Sen." = { id = "senior" }
+"Sen.I" = { id = "sen_1" }
+"Sen.II" = { id = "sen_2" }
+"Sen.III" = { id = "sen_3" }
+"Sen.IV" = { id = "sen_4" }
+"Sen.V" = { id = "sen_5" }
+"Kinder I" = { english = "Juveniles 1", id = "juv_1" }
+"Kinder II" = { english = "Juveniles 2", id = "juv_2" }
+"Junioren I" = { english = "Juniors 1", id = "jun_1" }
+"Junioren II" = { english = "Juniors 2", id = "jun_2" }
+"Jugend" = { english = "Youth", id = "youth" }
+"Hauptgruppe" = { english = "Adult", id = "adult" }
+"Hauptgruppe II" = { english = "Adult 2", id = "adult_2" }
+"Senioren I" = { english = "Senior 1", id = "sen_1" }
+"Senioren II" = { english = "Senior 2", id = "sen_2" }
+"Senioren III" = { english = "Senior 3", id = "sen_3" }
+"Senioren IV" = { english = "Senior 4", id = "sen_4" }
+"Senioren V" = { english = "Senior 5", id = "sen_5" }
+
+# Discipline Mappings
+[disciplines]
+"Standard" = { english = "Ballroom", id = "std" }
+"Latein" = { english = "Latin", id = "lat" }
+
+# Level Constraints (Dynamic for 2026 Updates)
+# The agent should use 'legacy' counts for competitions before 2026.
+[levels.E]
+min_dances = 3
+
+[levels.D]
+min_dances_legacy = 3
+min_dances_2026 = 4
+
+[levels.C]
+min_dances_legacy = 4
+min_dances_2026 = 5
+
+[levels.B]
+min_dances = 5
+
+[levels.A]
+min_dances = 5
+
+[levels.S]
+min_dances = 5

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/python/dancing_datacollection/config.py
+++ b/python/dancing_datacollection/config.py
@@ -1,0 +1,34 @@
+import os
+from typing import Any, Dict
+
+import toml
+
+CONFIG_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "config.toml"
+)
+
+
+def load_config(path: str = CONFIG_PATH) -> Dict[str, Any]:
+    if not os.path.exists(path):
+        return {}
+    with open(path, "r", encoding="utf-8") as f:
+        return toml.load(f)
+
+
+_CONFIG = load_config()
+
+
+def get_config() -> Dict[str, Any]:
+    return _CONFIG
+
+
+def get_age_groups() -> Dict[str, Dict[str, str]]:
+    return _CONFIG.get("age_groups", {})
+
+
+def get_disciplines() -> Dict[str, Dict[str, str]]:
+    return _CONFIG.get("disciplines", {})
+
+
+def get_levels() -> Dict[str, Dict[str, Any]]:
+    return _CONFIG.get("levels", {})

--- a/python/dancing_datacollection/data_defs/age_group.py
+++ b/python/dancing_datacollection/data_defs/age_group.py
@@ -1,0 +1,34 @@
+from enum import Enum
+from typing import Optional
+
+from dancing_datacollection.config import get_age_groups
+
+
+class AgeGroup(str, Enum):
+    JUV_1 = "juv_1"
+    JUV_2 = "juv_2"
+    JUN_1 = "jun_1"
+    JUN_2 = "jun_2"
+    YOUTH = "youth"
+    ADULT = "adult"
+    ADULT_2 = "adult_2"
+    SEN_1 = "sen_1"
+    SEN_2 = "sen_2"
+    SEN_3 = "sen_3"
+    SEN_4 = "sen_4"
+    SEN_5 = "sen_5"
+    SENIOR = "senior" # Added for generic senior
+
+    @classmethod
+    def from_german(cls, german_name: str) -> Optional["AgeGroup"]:
+        age_groups_config = get_age_groups()
+        if german_name in age_groups_config:
+            return cls(age_groups_config[german_name]["id"])
+        return None
+
+    def to_english(self) -> str:
+        age_groups_config = get_age_groups()
+        for german, info in age_groups_config.items():
+            if info["id"] == self.value and "english" in info:
+                return info["english"]
+        return self.value

--- a/python/dancing_datacollection/data_defs/competition.py
+++ b/python/dancing_datacollection/data_defs/competition.py
@@ -1,0 +1,24 @@
+import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+from .age_group import AgeGroup
+from .discipline import Discipline
+from .level import Level
+
+
+class CompetitionInfo(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str
+    comp_date: Optional[datetime.date] = None
+    age_group: Optional[AgeGroup] = None
+    discipline: Optional[Discipline] = None
+    level: Optional[Level] = None
+
+    @property
+    def min_dances(self) -> int:
+        if self.level:
+            return self.level.get_min_dances(self.comp_date)
+        return 0

--- a/python/dancing_datacollection/data_defs/discipline.py
+++ b/python/dancing_datacollection/data_defs/discipline.py
@@ -1,0 +1,30 @@
+from enum import Enum
+from typing import Optional
+
+from dancing_datacollection.config import get_disciplines
+
+
+class Discipline(str, Enum):
+    BALLROOM = "std"
+    LATIN = "lat"
+
+    @classmethod
+    def from_german(cls, german_name: str) -> Optional["Discipline"]:
+        disciplines_config = get_disciplines()
+        if german_name in disciplines_config:
+            return cls(disciplines_config[german_name]["id"])
+
+        # Common abbreviations
+        if german_name == "Std":
+            return cls.BALLROOM
+        if german_name == "Lat":
+            return cls.LATIN
+
+        return None
+
+    def to_english(self) -> str:
+        disciplines_config = get_disciplines()
+        for german, info in disciplines_config.items():
+            if info["id"] == self.value:
+                return info["english"]
+        return self.value

--- a/python/dancing_datacollection/data_defs/level.py
+++ b/python/dancing_datacollection/data_defs/level.py
@@ -1,0 +1,30 @@
+from datetime import date
+from enum import Enum
+from typing import Optional
+
+from dancing_datacollection.config import get_levels
+
+
+class Level(str, Enum):
+    E = "E"
+    D = "D"
+    C = "C"
+    B = "B"
+    A = "A"
+    S = "S"
+
+    def get_min_dances(self, competition_date: Optional[date] = None) -> int:
+        levels_config = get_levels()
+        config = levels_config.get(self.value, {})
+
+        if "min_dances" in config:
+            return config["min_dances"]
+
+        is_2026_or_later = False
+        if competition_date and competition_date.year >= 2026:
+            is_2026_or_later = True
+
+        if is_2026_or_later:
+            return config.get("min_dances_2026", config.get("min_dances_legacy", 0))
+        else:
+            return config.get("min_dances_legacy", 0)

--- a/python/dancing_datacollection/parsing/participant.py
+++ b/python/dancing_datacollection/parsing/participant.py
@@ -2,11 +2,13 @@ import logging
 from typing import List, Tuple
 
 from dancing_datacollection.data_defs.participant import Participant
+from dancing_datacollection.data_defs.competition import CompetitionInfo
 from dancing_datacollection.parsing.erg import extract_participants_from_erg
 from dancing_datacollection.parsing.ergwert import extract_participants_from_ergwert
 from dancing_datacollection.parsing.parsing_utils import (
     extract_event_name_from_soup,
     get_soup,
+    parse_competition_title,
 )
 from dancing_datacollection.parsing.tabges import extract_participants_from_tabges
 from dancing_datacollection.parsing.wert_er import extract_participants_from_wert_er
@@ -14,24 +16,37 @@ from dancing_datacollection.parsing.wert_er import extract_participants_from_wer
 logger = logging.getLogger(__name__)
 
 
+def extract_competition_info_from_html(html: str) -> CompetitionInfo:
+    """Extracts competition information from the HTML title."""
+    soup = get_soup(html)
+    title_tag = soup.find("title")
+    title = title_tag.get_text(strip=True) if title_tag else ""
+    return parse_competition_title(title)
+
+
 def extract_participants_and_event_name(
     html: str, filename: str
-) -> Tuple[List[Participant], str]:
+) -> Tuple[List[Participant], str, CompetitionInfo]:
     """
-    Extracts participants and the event name from HTML content.
+    Extracts participants, the event name, and competition info from HTML content.
 
     This function acts as a dispatcher, calling the appropriate
     participant extraction function based on the provided filename.
-    It also extracts the event name from the HTML's <title> tag.
+    It also extracts the event name and structured competition info
+    from the HTML's <title> tag.
 
     Args:
         html: The HTML content to parse.
         filename: The name of the file from which the HTML was sourced.
 
     Returns:
-        A tuple containing a list of participants and the event name.
+        A tuple containing:
+        - A list of participants.
+        - The sanitized event name.
+        - A CompetitionInfo object.
     """
     soup = get_soup(html)
+    info = extract_competition_info_from_html(html)
     event_name = extract_event_name_from_soup(soup)
     participants: List[Participant] = []
 
@@ -46,4 +61,4 @@ def extract_participants_and_event_name(
     else:
         logger.warning("Unknown filename for participant extraction: %s", filename)
 
-    return participants, event_name
+    return participants, event_name, info

--- a/tests/test_config_defs.py
+++ b/tests/test_config_defs.py
@@ -1,0 +1,37 @@
+import datetime
+from dancing_datacollection.data_defs.age_group import AgeGroup
+from dancing_datacollection.data_defs.discipline import Discipline
+from dancing_datacollection.data_defs.level import Level
+from dancing_datacollection.parsing.parsing_utils import parse_competition_title
+
+def test_parse_competition_title():
+    title = "11.05.2024 Hgr.II B Standard"
+    info = parse_competition_title(title)
+
+    assert info.comp_date == datetime.date(2024, 5, 11)
+    assert info.age_group == AgeGroup.ADULT_2
+    assert info.level == Level.B
+    assert info.discipline == Discipline.BALLROOM
+    assert info.min_dances == 5
+
+def test_parse_competition_title_multiword():
+    title = "11.05.2024 Kinder I D Latein"
+    info = parse_competition_title(title)
+
+    assert info.comp_date == datetime.date(2024, 5, 11)
+    assert info.age_group == AgeGroup.JUV_1
+    assert info.level == Level.D
+    assert info.discipline == Discipline.LATIN
+    assert info.min_dances == 3
+
+def test_level_min_dances_2026():
+    # Level D legacy: 3, 2026: 4
+    level_d = Level.D
+    assert level_d.get_min_dances(datetime.date(2024, 5, 11)) == 3
+    assert level_d.get_min_dances(datetime.date(2026, 1, 1)) == 4
+
+def test_level_min_dances_C():
+    # Level C legacy: 4, 2026: 5
+    level_c = Level.C
+    assert level_c.get_min_dances(datetime.date(2024, 5, 11)) == 4
+    assert level_c.get_min_dances(datetime.date(2026, 1, 1)) == 5


### PR DESCRIPTION
This change introduces a structured way to handle competition metadata through a central configuration file. Age groups, disciplines, and levels are now managed via Enums that use stable IDs defined in `config.toml`. The parsing logic has been improved to robustly extract this information from competition titles, and a new `metadata.json` file is produced for each competition. The dynamic rule for minimum dances starting in 2026 has also been implemented.

---
*PR created automatically by Jules for task [1924455123873152002](https://jules.google.com/task/1924455123873152002) started by @phyk*