### PR TITLE
Clean up redundant Python logic implemented in Rust

### DIFF
--- a/python/dancing_datacollection/main.py
+++ b/python/dancing_datacollection/main.py
@@ -2,12 +2,11 @@
 import argparse
 import logging
 import os
-import urllib.parse
-import urllib.robotparser
 from typing import Any, Dict, List
 
 from tqdm import tqdm
 
+from dancing_datacollection import download_sources
 from dancing_datacollection.config import load_config
 from dancing_datacollection.output import (
     save_committee,
@@ -26,8 +25,6 @@ from dancing_datacollection.parsing.ergwert import (
 )
 from dancing_datacollection.parsing.parsing_utils import (
     deduplicate_participants,
-    download_html,
-    extract_competition_links,
     get_soup,
     setup_logging,
 )
@@ -43,27 +40,6 @@ LOG_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "logs")
 
 logger = logging.getLogger(__name__)
 error_logger = logging.getLogger("error")
-
-
-def is_allowed_by_robots(url: str, user_agent: str = "*") -> bool:
-    parsed = urllib.parse.urlparse(url)
-    robots_url = f"{parsed.scheme}://{parsed.netloc}/robots.txt"
-    rp = urllib.robotparser.RobotFileParser()
-    try:
-        rp.set_url(robots_url)
-        rp.read()
-        allowed = rp.can_fetch(user_agent, url)
-        if not allowed:
-            logging.warning(
-                "robots.txt at %s disallows access to %s for user-agent %s",
-                robots_url,
-                url,
-                user_agent,
-            )
-        return allowed
-    except OSError as e:
-        logging.error("Failed to check robots.txt at %s: %s", robots_url, e)
-        return True
 
 
 def process_local_dir(local_dir: str) -> None:
@@ -176,91 +152,35 @@ def main() -> None:
         type=str,
         help="Process all .htm files in a local directory (for testing/offline)",
     )
+    arg_parser.add_argument(
+        "--config",
+        type=str,
+        default=CONFIG_PATH,
+        help="Path to the configuration file",
+    )
     args = arg_parser.parse_args()
     if args.local_dir:
         process_local_dir(args.local_dir)
         return
-    config = load_config()
-    urls = config.get("sources", {}).get("urls", [])
-    logger.info("Loaded %d base URLs from config.", len(urls))
-    if not urls:
-        logger.info("No URLs found in config. Exiting.")
-        return
-    for url in tqdm(urls, desc="Processing URLs", unit="url"):
-        if not is_allowed_by_robots(url):
-            logging.warning("robots.txt disallows scraping %s, skipping.", url)
-            continue
-        html = download_html(url)
-        if html is not None:
-            logger.info("Successfully downloaded HTML from %s", url)
-            comp_links = extract_competition_links(html, url)
-            logger.info("Found %d competition/event links at %s", len(comp_links), url)
-            if not comp_links:
-                logger.info("No competitions found at %s.", url)
-                continue
-            success_count = 0
-            for link in tqdm(comp_links, desc="Downloading competitions", unit="comp"):
-                try:
-                    comp_html = download_html(link)
-                    if comp_html is not None:
-                        success_count += 1
-                        base_url = link.rsplit("/", 1)[0]
-                        erg_url = f"{base_url}/erg.htm"
-                        erg_html = download_html(erg_url)
-                        if erg_html:
-                            participants, event_name, info = extract_participants_and_event_name(
-                                erg_html, "erg.htm"
-                            )
-                            logger.info("Parsed competition (erg.htm): %s", erg_url)
-                        else:
-                            filename_from_link = link.rsplit("/", 1)[-1]
-                            participants, event_name, info = extract_participants_and_event_name(
-                                comp_html, filename_from_link
-                            )
-                            logger.info("Parsed competition (index): %s", link)
-                        logger.info("  Participants: %d", len(participants))
-                        save_competition_data(event_name, participants, info)
-                        # After saving participants, try to download and save judges
-                        deck_url = f"{base_url}/deck.htm"
-                        deck_html = download_html(deck_url)
-                        if deck_html:
-                            soup = get_soup(deck_html)
-                            judges = extract_judges_from_deck(soup)
-                            logger.info("Judges found: %d", len(judges))
-                            save_judges(event_name, judges)
-                            committee = extract_committee_from_deck(soup)
-                            logger.info("Committee entries found: %d", len(committee))
-                            save_committee(event_name, committee)
-                        tabges_url = f"{base_url}/tabges.htm"
-                        tabges_html = download_html(tabges_url)
-                        if tabges_html:
-                            scores: List[Any] = []
-                            logger.info("Score entries found: %d", len(scores))
-                            save_scores(event_name, scores)
-                        ergwert_url = f"{base_url}/ergwert.htm"
-                        ergwert_html = download_html(ergwert_url)
-                        if ergwert_html:
-                            final_scores = extract_final_scoring(ergwert_html)
-                            logger.info("Final scoring entries found: %d", len(final_scores))
-                            save_final_scoring(event_name, final_scores)
-                            scores = extract_scores_from_ergwert(get_soup(ergwert_html))
-                            save_scores(event_name, scores)
-                    else:
-                        logger.warning("Failed to download competition page: %s", link)
-                except Exception:
-                    error_logger.exception("Error processing competition %s", link)
-            logger.info(
-                "Successfully downloaded %d/%d competition pages from %s",
-                success_count,
-                len(comp_links),
-                url,
-            )
-            logger.info("Summary for this URL:")
-            logger.info("  Competitions found: %d", len(comp_links))
-            logger.info("  Competitions successfully processed: %d", success_count)
+
+    logger.info("Starting data collection using Rust core...")
+    try:
+        download_sources(args.config)
+        logger.info("Scraping complete. Processing downloaded data...")
+
+        data_dir = "data"
+        if os.path.exists(data_dir):
+            for entry in os.scandir(data_dir):
+                if entry.is_dir():
+                    logger.info("Processing directory: %s", entry.path)
+                    process_local_dir(entry.path)
         else:
-            logger.warning("Skipping %s due to download error.", url)
-    logger.info("All URLs processed.")
+            logger.warning("Data directory not found after scraping.")
+
+    except Exception:
+        error_logger.exception("Data collection failed")
+
+    logger.info("All processing complete.")
 
 
 if __name__ == "__main__":

--- a/python/dancing_datacollection/parsing/parsing_utils.py
+++ b/python/dancing_datacollection/parsing/parsing_utils.py
@@ -1,10 +1,7 @@
 import logging
 import os
 import re
-import urllib.request
 from typing import List, Optional, Tuple, Union
-from urllib.error import URLError
-from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
 from bs4.element import Tag
@@ -83,28 +80,6 @@ def setup_logging(log_dir: Optional[str] = None) -> None:
     parsing_logger.debug("TEST: parsing_debug logger setup complete")
 
 
-def download_html(url: str) -> Optional[str]:
-    try:
-        logging.info("Downloading: %s", url)
-        with urllib.request.urlopen(url) as response:  # noqa: S310
-            html = response.read().decode("utf-8")
-        logging.info("Downloaded %d characters from %s", len(html), url)
-        return html
-    except URLError as e:
-        logging.error("Failed to download %s: %s", url, e)
-        return None
-
-
-def extract_competition_links(html: str, base_url: str) -> List[str]:
-    soup = BeautifulSoup(html, "html.parser")
-    links: List[str] = []
-    for a in soup.find_all("a", href=True):
-        if isinstance(a, Tag):
-            href = a.get("href")
-            if isinstance(href, str) and (href.endswith(".htm") or href.endswith(".html")):
-                full_url = urljoin(base_url, href)
-                links.append(full_url)
-    return links
 
 
 def deduplicate_participants(


### PR DESCRIPTION
This change removes Python code that was redundant with logic already implemented in the Rust core. Specifically, it delegates the scraping process (including robots.txt compliance and rate limiting) to the Rust `download_sources` function. The Python `main.py` now acts as a high-level orchestrator that triggers the Rust scraper and then processes the downloaded results using the existing Python parsers and Parquet archiving logic. Redundant utility functions for downloading and link extraction were also removed.

---
*PR created automatically by Jules for task [7121678182499611557](https://jules.google.com/task/7121678182499611557) started by @phyk*