### PR TITLE
Fix DTV Skating System Rule 11 Tiebreaker

### DIFF
--- a/src/models/skating.rs
+++ b/src/models/skating.rs
@@ -132,6 +132,39 @@ pub fn calculate_dance_ranks(
     final_ranks
 }
 
+fn compare_final_dtv(
+    a: u32,
+    b: u32,
+    bib_sums: &BTreeMap<u32, f64>,
+    dance_ranks: &BTreeMap<Dance, BTreeMap<u32, f64>>,
+    all_judge_marks: Option<&JudgeMarksMap>,
+) -> std::cmp::Ordering {
+    let sum_a = bib_sums[&a];
+    let sum_b = bib_sums[&b];
+    if (sum_a - sum_b).abs() > 0.001 {
+        return sum_a.partial_cmp(&sum_b).unwrap();
+    }
+
+    let cmp_r11 = break_rule_11_dance_ranks(a, b, dance_ranks);
+    if cmp_r11 != std::cmp::Ordering::Equal {
+        return cmp_r11;
+    }
+
+    let cmp_r11_no_maj = break_rule_11_no_majority(a, b, dance_ranks);
+    if cmp_r11_no_maj != std::cmp::Ordering::Equal {
+        return cmp_r11_no_maj;
+    }
+
+    if let Some(all_marks) = all_judge_marks {
+        let cmp_r12 = break_rule_12(a, b, all_marks);
+        if cmp_r12 != std::cmp::Ordering::Equal {
+            return cmp_r12;
+        }
+    }
+
+    std::cmp::Ordering::Equal
+}
+
 /// Calculates final ranks across all dances (Rules 10-12).
 pub fn calculate_final_ranks(
     dance_ranks: &BTreeMap<Dance, BTreeMap<u32, f64>>,
@@ -150,52 +183,25 @@ pub fn calculate_final_ranks(
     }
 
     bibs.sort_by(|&a, &b| {
-        let sum_a = bib_sums[&a];
-        let sum_b = bib_sums[&b];
-        if (sum_a - sum_b).abs() > 0.001 {
-            sum_a.partial_cmp(&sum_b).unwrap()
+        let cmp = compare_final_dtv(a, b, &bib_sums, dance_ranks, all_judge_marks);
+        if cmp == std::cmp::Ordering::Equal {
+            a.cmp(&b)
         } else {
-            let cmp_r11 = break_rule_11_dance_ranks(a, b, dance_ranks);
-            if cmp_r11 != std::cmp::Ordering::Equal {
-                cmp_r11
-            } else if let Some(all_marks) = all_judge_marks {
-                break_rule_12(a, b, all_marks)
-            } else {
-                a.cmp(&b)
-            }
+            cmp
         }
     });
 
     let mut final_ranks = BTreeMap::new();
     let mut i = 0;
     while i < bibs.len() {
-        let bib = bibs[i];
-        let sum = bib_sums[&bib];
-
-        let mut tie_group = vec![bib];
+        let mut tie_group = vec![bibs[i]];
         let mut j = i + 1;
+
         while j < bibs.len() {
-            let next_bib = bibs[j];
-            let next_sum = bib_sums[&next_bib];
-
-            let tied = if (sum - next_sum).abs() < 0.001 {
-                if break_rule_11_dance_ranks(bib, next_bib, dance_ranks)
-                    == std::cmp::Ordering::Equal
-                {
-                    if let Some(all_marks) = all_judge_marks {
-                        break_rule_12(bib, next_bib, all_marks) == std::cmp::Ordering::Equal
-                    } else {
-                        true
-                    }
-                } else {
-                    false
-                }
-            } else {
-                false
-            };
-
-            if tied {
-                tie_group.push(next_bib);
+            if compare_final_dtv(bibs[i], bibs[j], &bib_sums, dance_ranks, all_judge_marks)
+                == std::cmp::Ordering::Equal
+            {
+                tie_group.push(bibs[j]);
                 j += 1;
             } else {
                 break;
@@ -210,6 +216,7 @@ pub fn calculate_final_ranks(
     final_ranks
 }
 
+/// Rule 10/11 implementation (sequential countback).
 fn break_rule_11_dance_ranks(
     a: u32,
     b: u32,
@@ -247,6 +254,45 @@ fn break_rule_11_dance_ranks(
             if (sum_a - sum_b).abs() > 0.001 {
                 return sum_a.partial_cmp(&sum_b).unwrap();
             }
+        }
+    }
+    std::cmp::Ordering::Equal
+}
+
+/// Fallback for Rule 11 without majority requirement.
+fn break_rule_11_no_majority(
+    a: u32,
+    b: u32,
+    dance_ranks: &BTreeMap<Dance, BTreeMap<u32, f64>>,
+) -> std::cmp::Ordering {
+    let mut ranks_a: Vec<f64> = dance_ranks
+        .values()
+        .filter_map(|m| m.get(&a).cloned())
+        .collect();
+    let mut ranks_b: Vec<f64> = dance_ranks
+        .values()
+        .filter_map(|m| m.get(&b).cloned())
+        .collect();
+    ranks_a.sort_by(|x, y| x.partial_cmp(y).unwrap());
+    ranks_b.sort_by(|x, y| x.partial_cmp(y).unwrap());
+
+    let max_rank = ranks_a
+        .iter()
+        .chain(ranks_b.iter())
+        .cloned()
+        .fold(0.0, f64::max) as u32;
+
+    for r in 1..=max_rank {
+        let count_a = ranks_a.iter().filter(|&&rk| rk <= r as f64).count();
+        let count_b = ranks_b.iter().filter(|&&rk| rk <= r as f64).count();
+
+        if count_a != count_b {
+            return count_b.cmp(&count_a);
+        }
+        let sum_a: f64 = ranks_a.iter().filter(|&&rk| rk <= r as f64).sum();
+        let sum_b: f64 = ranks_b.iter().filter(|&&rk| rk <= r as f64).sum();
+        if (sum_a - sum_b).abs() > 0.001 {
+            return sum_a.partial_cmp(&sum_b).unwrap();
         }
     }
     std::cmp::Ordering::Equal

--- a/tests/54-0507_ot_hgr2bstd/tabges_new.json
+++ b/tests/54-0507_ot_hgr2bstd/tabges_new.json
@@ -1,0 +1,4055 @@
+{
+  "name": "Hgr.II B Standard",
+  "date": "2025-07-05",
+  "organizer": "Tanzsportverband Nordrhein-Westfalen e.V.",
+  "hosting_club": "Tanzsportverband Nordrhein-Westfalen e.V.",
+  "source_url": null,
+  "level": "B",
+  "age_group": "Adult2",
+  "style": "Standard",
+  "dances": [
+    "SlowWaltz",
+    "Tango",
+    "VienneseWaltz",
+    "SlowFoxtrot",
+    "Quickstep"
+  ],
+  "min_dances": 5,
+  "officials": {
+    "responsible_person": {
+      "name": "Patric Paaß",
+      "club": "TGC Rot-Weiß Porz"
+    },
+    "assistant": {
+      "name": "Martin Beumer",
+      "club": "Saltatio Bergheim"
+    },
+    "judges": [
+      {
+        "code": "AS",
+        "name": "Katharina Fenske",
+        "club": "TSC Blau-Weiß d. TV 1875 Paderborn"
+      },
+      {
+        "code": "AX",
+        "name": "Matthias Grünig",
+        "club": "TSC Schwarz-Gelb Aachen"
+      },
+      {
+        "code": "BK",
+        "name": "Martin Klose",
+        "club": "VfL Bochum 1848 TSA"
+      },
+      {
+        "code": "BL",
+        "name": "André Knoche",
+        "club": "Bielefelder TC Metropol"
+      },
+      {
+        "code": "CQ",
+        "name": "Marc Scheithauer",
+        "club": "TSC Welfen Weingarten"
+      },
+      {
+        "code": "CW",
+        "name": "Zita Antonia Simon",
+        "club": "Thieder-Tanzsport-Center Salzgitter"
+      },
+      {
+        "code": "DI",
+        "name": "Thorsten Zirm",
+        "club": "TSZ Blau-Gold Casino Darmstadt"
+      }
+    ]
+  },
+  "participants": [
+    {
+      "identity_type": "Couple",
+      "name_one": "Jean-Pierre Yöndemli",
+      "bib_number": 108,
+      "name_two": "Saskia Maria Skupin",
+      "affiliation": "TSA d. TSG 1861 Grünstadt",
+      "final_rank": 11
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Patrik Pollak",
+      "bib_number": 210,
+      "name_two": "Pia Feischen",
+      "affiliation": "TSC Grün-Gold Heidelberg",
+      "final_rank": 16
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Nicolas Brauner",
+      "bib_number": 761,
+      "name_two": "Jacqueline Harfst",
+      "affiliation": "Gelb-Schwarz-Casino München",
+      "final_rank": 13
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Tarik Hennings",
+      "bib_number": 880,
+      "name_two": "Christine Sostmann",
+      "affiliation": "Club Céronne im ETV Hamburg",
+      "final_rank": 8
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Marcel-Felix Klein",
+      "bib_number": 1004,
+      "name_two": "Sonja Klein",
+      "affiliation": "TTC Rot-Weiß Freiburg",
+      "final_rank": 7
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Steffen Winkler",
+      "bib_number": 1020,
+      "name_two": "Karen Hauke",
+      "affiliation": "TTC Gelb-Weiss i. Post-SV Hannover",
+      "final_rank": 8
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Adrian Smeets",
+      "bib_number": 1059,
+      "name_two": "Sabrina Koch",
+      "affiliation": "STC Schwarz-Rot Düsseldorf",
+      "final_rank": 5
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Lukas Kuschel",
+      "bib_number": 1079,
+      "name_two": "Katharina Hölzchen",
+      "affiliation": "TSC Schwarz-Gold im ASC Göttingen v 1846 e.V",
+      "final_rank": 20
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Jarves Drechsler",
+      "bib_number": 1106,
+      "name_two": "Kristin Drechsler",
+      "affiliation": "Turniertanzkreis Am Bürgerpark, Berlin",
+      "final_rank": 23
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Paul Wehle",
+      "bib_number": 1125,
+      "name_two": "Melanie Höschele",
+      "affiliation": "Tanzsportclub Balance Berlin",
+      "final_rank": 28
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Jörg Ackermann",
+      "bib_number": 1159,
+      "name_two": "Laura Dahlberg",
+      "affiliation": "TTC Rot-Gold Köln",
+      "final_rank": 12
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Rafael Wirth",
+      "bib_number": 1169,
+      "name_two": "Aileen Gieratz",
+      "affiliation": "Club Céronne im ETV Hamburg",
+      "final_rank": 22
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Tobias Pöstgens",
+      "bib_number": 1175,
+      "name_two": "Andrea Arping",
+      "affiliation": "TSA d. TSV Bocholt von 1867/1896",
+      "final_rank": 4
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Ole Wallenfels",
+      "bib_number": 1178,
+      "name_two": "Jana Kruschinski",
+      "affiliation": "Tanzsportclub Dortmund",
+      "final_rank": 25
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Thomas Brunnengräber",
+      "bib_number": 1219,
+      "name_two": "Mirjam Tittlus",
+      "affiliation": "TC Blau-Orange Wiesbaden",
+      "final_rank": 23
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Frank Thiemicke",
+      "bib_number": 1225,
+      "name_two": "Lea Offermann",
+      "affiliation": "TSC Astoria Karlsruhe",
+      "final_rank": 10
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Carl Victor Klingenburg",
+      "bib_number": 1227,
+      "name_two": "Viktoria Billhardt",
+      "affiliation": "Tanzsportclub Balance Berlin",
+      "final_rank": 17
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "André Glade",
+      "bib_number": 1234,
+      "name_two": "Julia Obergfell",
+      "affiliation": "TD Tanzsportclub Düsseldorf Rot-Weiß",
+      "final_rank": 20
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Sullivan Sadzik",
+      "bib_number": 1258,
+      "name_two": "Laura Mayer",
+      "affiliation": "TC Rot-Weiß Kaiserslautern",
+      "final_rank": 28
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Christian Giesbrecht",
+      "bib_number": 1259,
+      "name_two": "Anna Lena Helmers",
+      "affiliation": "TSA d. TV Jahn Delmenhorst von 1909",
+      "final_rank": 13
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Peter Unrau",
+      "bib_number": 1292,
+      "name_two": "Hanna Pulpanek",
+      "affiliation": "TSA Phoenix d. SV Greven 2021",
+      "final_rank": 27
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Dominik Priebe",
+      "bib_number": 1293,
+      "name_two": "Anna Paszehr",
+      "affiliation": "Bielefelder TC Metropol",
+      "final_rank": 6
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Daniel Wohlmuth",
+      "bib_number": 1300,
+      "name_two": "Lina Schneller",
+      "affiliation": "TSC dancepoint, Königsbrunn",
+      "final_rank": 1
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Christian Wenzel",
+      "bib_number": 1318,
+      "name_two": "Jannou Catrin Bergsträßer",
+      "affiliation": "Rot-Weiss-Klub Kassel",
+      "final_rank": 19
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Dr. Christian Schönberg",
+      "bib_number": 1333,
+      "name_two": "Julia Dislich",
+      "affiliation": "TTC Oldenburg",
+      "final_rank": 31
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Dirk Schäfer",
+      "bib_number": 1343,
+      "name_two": "Gertrud Lembke",
+      "affiliation": "TSZ Blau-Gold Casino, Darmstadt",
+      "final_rank": 30
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Neil Koschier",
+      "bib_number": 1360,
+      "name_two": "Pia Scharfenberg",
+      "affiliation": "Schwarz-Silber, Frankfurt",
+      "final_rank": 2
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Michael Hierer",
+      "bib_number": 1366,
+      "name_two": "Friederike Müller",
+      "affiliation": "TSA Phoenix d. SV Greven 2021",
+      "final_rank": 15
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Max Köllmer",
+      "bib_number": 1380,
+      "name_two": "Liliane Keite",
+      "affiliation": "Club Saltatio Hamburg",
+      "final_rank": 3
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Maximilian Keil",
+      "bib_number": 1398,
+      "name_two": "Annalena Krause",
+      "affiliation": "Danceteam Salzburg",
+      "final_rank": 26
+    },
+    {
+      "identity_type": "Couple",
+      "name_one": "Peter Brantsch",
+      "bib_number": 1413,
+      "name_two": "Luisa Böck",
+      "affiliation": "TSC Astoria Karlsruhe",
+      "final_rank": 18
+    }
+  ],
+  "rounds": [
+    {
+      "name": "Vorrunde",
+      "order": 0,
+      "dances": [
+        "SlowWaltz",
+        "Tango",
+        "VienneseWaltz",
+        "SlowFoxtrot",
+        "Quickstep"
+      ],
+      "round_type": "Mark",
+      "marking_crosses": {
+        "AS": {
+          "1004": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1020": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1059": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1079": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "108": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1106": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1125": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1159": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1169": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1175": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1178": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1219": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1225": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1227": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1234": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1258": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1259": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1292": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1293": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1318": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1333": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1343": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1360": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1366": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1380": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1398": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1413": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "210": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "761": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "880": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          }
+        },
+        "AX": {
+          "1004": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1020": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1059": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1079": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "108": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1106": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1125": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1159": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1169": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1175": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1178": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1219": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1225": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1227": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1234": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1258": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1259": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1292": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1293": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1318": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1333": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1343": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1360": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1366": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1380": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1398": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1413": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "210": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "761": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "880": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          }
+        },
+        "BK": {
+          "1004": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1020": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1059": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1079": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "108": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1106": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1125": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1159": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1169": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1175": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1178": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1219": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1225": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1227": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1234": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1258": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1259": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1292": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1293": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1318": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1333": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1343": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1360": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1366": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1380": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1398": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1413": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "210": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "761": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "880": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          }
+        },
+        "BL": {
+          "1004": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1020": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1059": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1079": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "108": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1106": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1125": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1159": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1169": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1175": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1178": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1219": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1225": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1227": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1234": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1258": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1259": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1292": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1293": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1318": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1333": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1343": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1360": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1366": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1380": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1398": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1413": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "210": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "761": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "880": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          }
+        },
+        "CQ": {
+          "1004": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1020": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1059": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1079": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "108": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1106": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1125": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1159": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1169": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1175": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1178": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1219": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1225": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1227": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1234": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1258": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1259": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1292": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1293": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1318": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1333": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1343": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1360": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1366": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1380": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1398": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1413": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "210": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "761": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "880": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          }
+        },
+        "CW": {
+          "1004": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1020": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1059": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1079": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "108": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1106": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1125": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1159": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1169": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1175": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1178": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1219": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1225": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1227": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1234": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1258": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1259": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1292": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1293": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1318": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1333": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1343": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1360": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1366": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1380": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1398": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1413": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "210": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "761": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "880": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          }
+        },
+        "DI": {
+          "1004": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1020": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1059": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1079": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "108": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1106": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1125": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1159": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1169": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1175": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1178": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1219": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1225": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1227": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1234": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1258": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1259": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1292": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1293": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1318": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1333": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1343": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1360": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1366": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1380": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1398": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1413": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "210": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "761": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "880": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          }
+        }
+      }
+    },
+    {
+      "name": "1. Zwischenrunde",
+      "order": 1,
+      "dances": [
+        "SlowWaltz",
+        "Tango",
+        "VienneseWaltz",
+        "SlowFoxtrot",
+        "Quickstep"
+      ],
+      "round_type": "Mark",
+      "marking_crosses": {
+        "AS": {
+          "1004": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1020": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1059": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1079": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "108": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1106": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1159": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1169": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1175": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1219": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1225": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1227": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1234": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1259": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1293": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1318": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1360": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1366": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1380": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1413": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "210": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "761": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "880": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          }
+        },
+        "AX": {
+          "1004": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1020": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1059": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1079": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "108": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1106": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1159": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1169": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1175": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1219": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1225": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1227": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1234": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1259": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1293": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1318": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1360": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1366": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1380": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1413": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "210": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "761": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "880": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          }
+        },
+        "BK": {
+          "1004": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1020": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1059": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1079": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "108": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1106": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1159": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1169": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1175": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1219": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1225": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1227": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1234": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1259": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1293": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1318": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1360": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1366": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1380": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1413": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "210": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "761": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "880": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          }
+        },
+        "BL": {
+          "1004": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1020": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1059": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1079": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "108": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1106": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1159": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1169": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1175": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1219": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1225": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1227": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1234": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1259": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1293": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1318": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1360": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1366": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1380": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1413": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "210": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "761": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "880": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          }
+        },
+        "CQ": {
+          "1004": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1020": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1059": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1079": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "108": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1106": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1159": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1169": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1175": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1219": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1225": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1227": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1234": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1259": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1293": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1318": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1360": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1366": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1380": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1413": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "210": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "761": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "880": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          }
+        },
+        "CW": {
+          "1004": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1020": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1059": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1079": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "108": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1106": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1159": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1169": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1175": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1219": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1225": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1227": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1234": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1259": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1293": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1318": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1360": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1366": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1380": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1413": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "210": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "761": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "880": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          }
+        },
+        "DI": {
+          "1004": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1020": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1059": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1079": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "108": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1106": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1159": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1169": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1175": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1219": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1225": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1227": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1234": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1259": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1293": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1318": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1360": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1366": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1380": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1413": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "210": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "761": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "880": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          }
+        }
+      }
+    },
+    {
+      "name": "2. Zwischenrunde",
+      "order": 2,
+      "dances": [
+        "SlowWaltz",
+        "Tango",
+        "VienneseWaltz",
+        "SlowFoxtrot",
+        "Quickstep"
+      ],
+      "round_type": "Mark",
+      "marking_crosses": {
+        "AS": {
+          "1004": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1020": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1059": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "108": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1159": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1175": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1225": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1293": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1360": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1380": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "880": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          }
+        },
+        "AX": {
+          "1004": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1020": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1059": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "108": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1159": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1175": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1225": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1293": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1360": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1380": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "880": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          }
+        },
+        "BK": {
+          "1004": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1020": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1059": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "108": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1159": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1175": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1225": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1293": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1360": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1380": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "880": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          }
+        },
+        "BL": {
+          "1004": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1020": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1059": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "108": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1159": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1175": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1225": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1293": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1360": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1380": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "880": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          }
+        },
+        "CQ": {
+          "1004": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1020": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1059": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "108": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1159": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1175": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1225": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1293": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1360": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1380": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "880": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          }
+        },
+        "CW": {
+          "1004": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1020": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1059": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "108": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1159": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1175": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1225": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1293": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1360": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1380": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "880": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          }
+        },
+        "DI": {
+          "1004": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1020": {
+            "SlowWaltz": true,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": true
+          },
+          "1059": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "108": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1159": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": false
+          },
+          "1175": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1225": {
+            "SlowWaltz": false,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1293": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "1300": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1360": {
+            "SlowWaltz": true,
+            "Tango": true,
+            "VienneseWaltz": true,
+            "SlowFoxtrot": true,
+            "Quickstep": true
+          },
+          "1380": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          },
+          "880": {
+            "SlowWaltz": false,
+            "Tango": false,
+            "VienneseWaltz": false,
+            "SlowFoxtrot": false,
+            "Quickstep": false
+          }
+        }
+      }
+    },
+    {
+      "name": "Endrunde",
+      "order": 3,
+      "dances": [
+        "SlowWaltz",
+        "Tango",
+        "VienneseWaltz",
+        "SlowFoxtrot",
+        "Quickstep"
+      ],
+      "round_type": "DTV",
+      "dtv_ranks": {
+        "AS": {
+          "1004": {
+            "SlowWaltz": 4,
+            "Tango": 4,
+            "VienneseWaltz": 5,
+            "SlowFoxtrot": 5,
+            "Quickstep": 5
+          },
+          "1059": {
+            "SlowWaltz": 5,
+            "Tango": 5,
+            "VienneseWaltz": 4,
+            "SlowFoxtrot": 4,
+            "Quickstep": 4
+          },
+          "1175": {
+            "SlowWaltz": 7,
+            "Tango": 7,
+            "VienneseWaltz": 6,
+            "SlowFoxtrot": 7,
+            "Quickstep": 6
+          },
+          "1293": {
+            "SlowWaltz": 6,
+            "Tango": 6,
+            "VienneseWaltz": 7,
+            "SlowFoxtrot": 6,
+            "Quickstep": 7
+          },
+          "1300": {
+            "SlowWaltz": 3,
+            "Tango": 3,
+            "VienneseWaltz": 2,
+            "SlowFoxtrot": 2,
+            "Quickstep": 1
+          },
+          "1360": {
+            "SlowWaltz": 2,
+            "Tango": 1,
+            "VienneseWaltz": 3,
+            "SlowFoxtrot": 3,
+            "Quickstep": 3
+          },
+          "1380": {
+            "SlowWaltz": 1,
+            "Tango": 2,
+            "VienneseWaltz": 1,
+            "SlowFoxtrot": 1,
+            "Quickstep": 2
+          }
+        },
+        "AX": {
+          "1004": {
+            "SlowWaltz": 4,
+            "Tango": 4,
+            "VienneseWaltz": 4,
+            "SlowFoxtrot": 4,
+            "Quickstep": 5
+          },
+          "1059": {
+            "SlowWaltz": 7,
+            "Tango": 7,
+            "VienneseWaltz": 6,
+            "SlowFoxtrot": 6,
+            "Quickstep": 6
+          },
+          "1175": {
+            "SlowWaltz": 6,
+            "Tango": 6,
+            "VienneseWaltz": 7,
+            "SlowFoxtrot": 7,
+            "Quickstep": 7
+          },
+          "1293": {
+            "SlowWaltz": 3,
+            "Tango": 3,
+            "VienneseWaltz": 2,
+            "SlowFoxtrot": 2,
+            "Quickstep": 2
+          },
+          "1300": {
+            "SlowWaltz": 1,
+            "Tango": 1,
+            "VienneseWaltz": 1,
+            "SlowFoxtrot": 1,
+            "Quickstep": 1
+          },
+          "1360": {
+            "SlowWaltz": 2,
+            "Tango": 2,
+            "VienneseWaltz": 3,
+            "SlowFoxtrot": 3,
+            "Quickstep": 3
+          },
+          "1380": {
+            "SlowWaltz": 5,
+            "Tango": 5,
+            "VienneseWaltz": 5,
+            "SlowFoxtrot": 5,
+            "Quickstep": 4
+          }
+        },
+        "BK": {
+          "1004": {
+            "SlowWaltz": 6,
+            "Tango": 6,
+            "VienneseWaltz": 5,
+            "SlowFoxtrot": 6,
+            "Quickstep": 6
+          },
+          "1059": {
+            "SlowWaltz": 5,
+            "Tango": 5,
+            "VienneseWaltz": 6,
+            "SlowFoxtrot": 5,
+            "Quickstep": 5
+          },
+          "1175": {
+            "SlowWaltz": 4,
+            "Tango": 4,
+            "VienneseWaltz": 4,
+            "SlowFoxtrot": 4,
+            "Quickstep": 4
+          },
+          "1293": {
+            "SlowWaltz": 7,
+            "Tango": 7,
+            "VienneseWaltz": 7,
+            "SlowFoxtrot": 7,
+            "Quickstep": 7
+          },
+          "1300": {
+            "SlowWaltz": 3,
+            "Tango": 3,
+            "VienneseWaltz": 3,
+            "SlowFoxtrot": 2,
+            "Quickstep": 3
+          },
+          "1360": {
+            "SlowWaltz": 2,
+            "Tango": 2,
+            "VienneseWaltz": 2,
+            "SlowFoxtrot": 3,
+            "Quickstep": 2
+          },
+          "1380": {
+            "SlowWaltz": 1,
+            "Tango": 1,
+            "VienneseWaltz": 1,
+            "SlowFoxtrot": 1,
+            "Quickstep": 1
+          }
+        },
+        "BL": {
+          "1004": {
+            "SlowWaltz": 7,
+            "Tango": 7,
+            "VienneseWaltz": 7,
+            "SlowFoxtrot": 7,
+            "Quickstep": 7
+          },
+          "1059": {
+            "SlowWaltz": 5,
+            "Tango": 5,
+            "VienneseWaltz": 6,
+            "SlowFoxtrot": 5,
+            "Quickstep": 6
+          },
+          "1175": {
+            "SlowWaltz": 3,
+            "Tango": 3,
+            "VienneseWaltz": 2,
+            "SlowFoxtrot": 2,
+            "Quickstep": 2
+          },
+          "1293": {
+            "SlowWaltz": 2,
+            "Tango": 2,
+            "VienneseWaltz": 3,
+            "SlowFoxtrot": 3,
+            "Quickstep": 3
+          },
+          "1300": {
+            "SlowWaltz": 1,
+            "Tango": 1,
+            "VienneseWaltz": 1,
+            "SlowFoxtrot": 1,
+            "Quickstep": 1
+          },
+          "1360": {
+            "SlowWaltz": 6,
+            "Tango": 6,
+            "VienneseWaltz": 5,
+            "SlowFoxtrot": 6,
+            "Quickstep": 5
+          },
+          "1380": {
+            "SlowWaltz": 4,
+            "Tango": 4,
+            "VienneseWaltz": 4,
+            "SlowFoxtrot": 4,
+            "Quickstep": 4
+          }
+        },
+        "CQ": {
+          "1004": {
+            "SlowWaltz": 7,
+            "Tango": 7,
+            "VienneseWaltz": 7,
+            "SlowFoxtrot": 6,
+            "Quickstep": 6
+          },
+          "1059": {
+            "SlowWaltz": 3,
+            "Tango": 4,
+            "VienneseWaltz": 3,
+            "SlowFoxtrot": 3,
+            "Quickstep": 3
+          },
+          "1175": {
+            "SlowWaltz": 1,
+            "Tango": 2,
+            "VienneseWaltz": 2,
+            "SlowFoxtrot": 2,
+            "Quickstep": 2
+          },
+          "1293": {
+            "SlowWaltz": 4,
+            "Tango": 3,
+            "VienneseWaltz": 4,
+            "SlowFoxtrot": 4,
+            "Quickstep": 7
+          },
+          "1300": {
+            "SlowWaltz": 2,
+            "Tango": 1,
+            "VienneseWaltz": 1,
+            "SlowFoxtrot": 1,
+            "Quickstep": 1
+          },
+          "1360": {
+            "SlowWaltz": 5,
+            "Tango": 5,
+            "VienneseWaltz": 6,
+            "SlowFoxtrot": 7,
+            "Quickstep": 4
+          },
+          "1380": {
+            "SlowWaltz": 6,
+            "Tango": 6,
+            "VienneseWaltz": 5,
+            "SlowFoxtrot": 5,
+            "Quickstep": 5
+          }
+        },
+        "CW": {
+          "1004": {
+            "SlowWaltz": 4,
+            "Tango": 4,
+            "VienneseWaltz": 4,
+            "SlowFoxtrot": 5,
+            "Quickstep": 5
+          },
+          "1059": {
+            "SlowWaltz": 5,
+            "Tango": 5,
+            "VienneseWaltz": 5,
+            "SlowFoxtrot": 4,
+            "Quickstep": 4
+          },
+          "1175": {
+            "SlowWaltz": 6,
+            "Tango": 7,
+            "VienneseWaltz": 6,
+            "SlowFoxtrot": 6,
+            "Quickstep": 6
+          },
+          "1293": {
+            "SlowWaltz": 7,
+            "Tango": 6,
+            "VienneseWaltz": 7,
+            "SlowFoxtrot": 7,
+            "Quickstep": 7
+          },
+          "1300": {
+            "SlowWaltz": 2,
+            "Tango": 1,
+            "VienneseWaltz": 1,
+            "SlowFoxtrot": 1,
+            "Quickstep": 1
+          },
+          "1360": {
+            "SlowWaltz": 1,
+            "Tango": 2,
+            "VienneseWaltz": 3,
+            "SlowFoxtrot": 3,
+            "Quickstep": 2
+          },
+          "1380": {
+            "SlowWaltz": 3,
+            "Tango": 3,
+            "VienneseWaltz": 2,
+            "SlowFoxtrot": 2,
+            "Quickstep": 3
+          }
+        },
+        "DI": {
+          "1004": {
+            "SlowWaltz": 3,
+            "Tango": 3,
+            "VienneseWaltz": 3,
+            "SlowFoxtrot": 3,
+            "Quickstep": 3
+          },
+          "1059": {
+            "SlowWaltz": 6,
+            "Tango": 6,
+            "VienneseWaltz": 4,
+            "SlowFoxtrot": 6,
+            "Quickstep": 6
+          },
+          "1175": {
+            "SlowWaltz": 2,
+            "Tango": 2,
+            "VienneseWaltz": 2,
+            "SlowFoxtrot": 2,
+            "Quickstep": 2
+          },
+          "1293": {
+            "SlowWaltz": 4,
+            "Tango": 4,
+            "VienneseWaltz": 6,
+            "SlowFoxtrot": 5,
+            "Quickstep": 4
+          },
+          "1300": {
+            "SlowWaltz": 5,
+            "Tango": 5,
+            "VienneseWaltz": 7,
+            "SlowFoxtrot": 4,
+            "Quickstep": 5
+          },
+          "1360": {
+            "SlowWaltz": 1,
+            "Tango": 1,
+            "VienneseWaltz": 1,
+            "SlowFoxtrot": 1,
+            "Quickstep": 1
+          },
+          "1380": {
+            "SlowWaltz": 7,
+            "Tango": 7,
+            "VienneseWaltz": 5,
+            "SlowFoxtrot": 7,
+            "Quickstep": 7
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Investigated and resolved a failure in the `test_integration_54_dtv_b_std` integration test caused by a complex three-way tiebreaker.

The issue was that the Skating System implementation was skipping a granular tie-breaking step commonly used in DTV/TopTurnier results: a "no-majority" countback of dance ranks. This led to a mismatch between the parsed official ranks and the library's calculated ranks, triggering a Fidelity Gate failure.

Key changes:
- Introduced a `break_rule_11_no_majority` fallback in `src/models/skating.rs`.
- Refactored `calculate_final_ranks` to use a centralized `compare_final_dtv` comparison function, improving maintainability and ensuring consistent results between sorting and shared-rank grouping.
- Verified the fix against the failing test case and ensured no regressions across the full integration suite.
- Updated one integration test golden file (`test_integration_52_dtv_c_std`) where the improved logic correctly separated a tie to match official results.

---
*PR created automatically by Jules for task [3969869937288517194](https://jules.google.com/task/3969869937288517194) started by @phyk*