### PR TITLE
Fix WDSF Scoring Fidelity and Data Loss

### DIFF
--- a/src/sources/dtv_native.rs
+++ b/src/sources/dtv_native.rs
@@ -214,15 +214,16 @@ fn merge_round_data(existing: &mut crate::models::RoundData, new: crate::models:
                 for (bib, n_dance_map) in n_bib_map {
                     let e_dance_map = e_bib_map.entry(bib).or_default();
                     for (dance, n_score) in n_dance_map {
-                        let e_score = e_dance_map
-                            .entry(dance)
-                            .or_insert_with(|| crate::models::WDSFScore {
-                                technical_quality: 0.0,
-                                movement_to_music: 0.0,
-                                partnering_skills: 0.0,
-                                choreography: 0.0,
-                                total: 0.0,
-                            });
+                        let e_score =
+                            e_dance_map
+                                .entry(dance)
+                                .or_insert_with(|| crate::models::WDSFScore {
+                                    technical_quality: 0.0,
+                                    movement_to_music: 0.0,
+                                    partnering_skills: 0.0,
+                                    choreography: 0.0,
+                                    total: 0.0,
+                                });
                         if n_score.technical_quality > 0.0 {
                             e_score.technical_quality = n_score.technical_quality;
                         }

--- a/src/sources/dtv_native.rs
+++ b/src/sources/dtv_native.rs
@@ -213,8 +213,32 @@ fn merge_round_data(existing: &mut crate::models::RoundData, new: crate::models:
                 let e_bib_map = e_map.entry(judge).or_default();
                 for (bib, n_dance_map) in n_bib_map {
                     let e_dance_map = e_bib_map.entry(bib).or_default();
-                    if n_dance_map.len() > e_dance_map.len() {
-                        *e_dance_map = n_dance_map;
+                    for (dance, n_score) in n_dance_map {
+                        let e_score = e_dance_map
+                            .entry(dance)
+                            .or_insert_with(|| crate::models::WDSFScore {
+                                technical_quality: 0.0,
+                                movement_to_music: 0.0,
+                                partnering_skills: 0.0,
+                                choreography: 0.0,
+                                total: 0.0,
+                            });
+                        if n_score.technical_quality > 0.0 {
+                            e_score.technical_quality = n_score.technical_quality;
+                        }
+                        if n_score.movement_to_music > 0.0 {
+                            e_score.movement_to_music = n_score.movement_to_music;
+                        }
+                        if n_score.partnering_skills > 0.0 {
+                            e_score.partnering_skills = n_score.partnering_skills;
+                        }
+                        if n_score.choreography > 0.0 {
+                            e_score.choreography = n_score.choreography;
+                        }
+                        e_score.total = e_score.technical_quality
+                            + e_score.movement_to_music
+                            + e_score.partnering_skills
+                            + e_score.choreography;
                     }
                 }
             }

--- a/src/sources/html_gen.rs
+++ b/src/sources/html_gen.rs
@@ -109,7 +109,7 @@ pub fn competition_to_html(comp: &Competition) -> String {
             .filter(|r| r.data.participant_bibs().contains(&p.bib_number))
             .collect();
         // Sort descending: Final (highest order) at the top of the cell
-        p_rounds.sort_by(|a, b| b.order.cmp(&a.order));
+        p_rounds.sort_by_key(|r| std::cmp::Reverse(r.order));
 
         if p_rounds.is_empty() {
             continue;

--- a/src/sources/html_gen.rs
+++ b/src/sources/html_gen.rs
@@ -333,11 +333,29 @@ fn get_mark(data: &RoundData, judge_code: &str, bib: u32, dance: Dance) -> Strin
                 .unwrap_or_else(|| "&nbsp;".to_string())
         }
         RoundData::WDSF { wdsf_scores } => {
-            wdsf_scores.get(judge_code)
+            let score = wdsf_scores.get(judge_code)
                 .and_then(|jm| jm.get(&bib))
-                .and_then(|pm| pm.get(&dance))
-                .map(|s| format!("{:.2}", s.total))
-                .unwrap_or_else(|| "&nbsp;".to_string())
+                .and_then(|pm| pm.get(&dance));
+
+            if let Some(s) = score {
+                let mut parts = Vec::new();
+                if s.technical_quality > 0.0 {
+                    parts.push(format!("{:.2}", s.technical_quality));
+                }
+                if s.partnering_skills > 0.0 {
+                    parts.push(format!("{:.2}", s.partnering_skills));
+                }
+                if s.movement_to_music > 0.0 {
+                    parts.push(format!("{:.2}", s.movement_to_music));
+                }
+                if s.choreography > 0.0 {
+                    parts.push(format!("{:.2}", s.choreography));
+                }
+                if !parts.is_empty() {
+                    return parts.join("|");
+                }
+            }
+            "&nbsp;".to_string()
         }
     }
 }

--- a/src/sources/html_gen.rs
+++ b/src/sources/html_gen.rs
@@ -11,16 +11,40 @@ pub fn competition_to_html(comp: &Competition) -> String {
     writeln!(html, "  <meta charset=\"utf-8\">").unwrap();
     writeln!(html, "  <title>{}</title>", comp.name).unwrap();
     writeln!(html, "  <style>").unwrap();
-    writeln!(html, "    body {{ font-family: Arial, sans-serif; font-size: 11px; color: #333; }}").unwrap();
-    writeln!(html, "    table {{ border-collapse: collapse; width: 100%; margin-top: 10px; }}").unwrap();
+    writeln!(
+        html,
+        "    body {{ font-family: Arial, sans-serif; font-size: 11px; color: #333; }}"
+    )
+    .unwrap();
+    writeln!(
+        html,
+        "    table {{ border-collapse: collapse; width: 100%; margin-top: 10px; }}"
+    )
+    .unwrap();
     writeln!(html, "    th, td {{ border: 1px solid #999; padding: 3px; text-align: center; vertical-align: middle; }}").unwrap();
-    writeln!(html, "    .header {{ background-color: #eee; font-weight: bold; }}").unwrap();
+    writeln!(
+        html,
+        "    .header {{ background-color: #eee; font-weight: bold; }}"
+    )
+    .unwrap();
     writeln!(html, "    .left {{ text-align: left; }}").unwrap();
-    writeln!(html, "    .participant {{ font-weight: bold; display: block; }}").unwrap();
-    writeln!(html, "    .affiliation {{ font-style: italic; font-size: 9px; display: block; color: #666; }}").unwrap();
+    writeln!(
+        html,
+        "    .participant {{ font-weight: bold; display: block; }}"
+    )
+    .unwrap();
+    writeln!(
+        html,
+        "    .affiliation {{ font-style: italic; font-size: 9px; display: block; color: #666; }}"
+    )
+    .unwrap();
     writeln!(html, "    h1 {{ font-size: 16px; margin: 5px 0; }}").unwrap();
     writeln!(html, "    p {{ margin: 2px 0; }}").unwrap();
-    writeln!(html, "    .total-cell {{ background-color: #f9f9f9; font-weight: bold; }}").unwrap();
+    writeln!(
+        html,
+        "    .total-cell {{ background-color: #f9f9f9; font-weight: bold; }}"
+    )
+    .unwrap();
     writeln!(html, "  </style>").unwrap();
     writeln!(html, "</head>").unwrap();
     writeln!(html, "<body>").unwrap();
@@ -284,13 +308,32 @@ pub fn competition_to_html(comp: &Competition) -> String {
     writeln!(html, "    <h3>Officials</h3>").unwrap();
     writeln!(html, "    <ul>").unwrap();
     if let Some(ref rp) = comp.officials.responsible_person {
-        writeln!(html, "      <li>Responsible: {} ({})</li>", rp.name, rp.club.as_deref().unwrap_or("-")).unwrap();
+        writeln!(
+            html,
+            "      <li>Responsible: {} ({})</li>",
+            rp.name,
+            rp.club.as_deref().unwrap_or("-")
+        )
+        .unwrap();
     }
     if let Some(ref asst) = comp.officials.assistant {
-        writeln!(html, "      <li>Assistant: {} ({})</li>", asst.name, asst.club.as_deref().unwrap_or("-")).unwrap();
+        writeln!(
+            html,
+            "      <li>Assistant: {} ({})</li>",
+            asst.name,
+            asst.club.as_deref().unwrap_or("-")
+        )
+        .unwrap();
     }
     for judge in &comp.officials.judges {
-        writeln!(html, "      <li>Judge {}: {} ({})</li>", judge.code, judge.name, judge.club.as_deref().unwrap_or("-")).unwrap();
+        writeln!(
+            html,
+            "      <li>Judge {}: {} ({})</li>",
+            judge.code,
+            judge.name,
+            judge.club.as_deref().unwrap_or("-")
+        )
+        .unwrap();
     }
     writeln!(html, "    </ul>").unwrap();
     writeln!(html, "  </div>").unwrap();
@@ -318,22 +361,21 @@ fn dance_name(dance: Dance) -> &'static str {
 
 fn get_mark(data: &RoundData, judge_code: &str, bib: u32, dance: Dance) -> String {
     match data {
-        RoundData::Marking { marking_crosses } => {
-            marking_crosses.get(judge_code)
-                .and_then(|jm| jm.get(&bib))
-                .and_then(|pm| pm.get(&dance))
-                .map(|&m| if m { "x".to_string() } else { "-".to_string() })
-                .unwrap_or_else(|| "&nbsp;".to_string())
-        }
-        RoundData::DTV { dtv_ranks } => {
-            dtv_ranks.get(judge_code)
-                .and_then(|jm| jm.get(&bib))
-                .and_then(|pm| pm.get(&dance))
-                .map(|&r| r.to_string())
-                .unwrap_or_else(|| "&nbsp;".to_string())
-        }
+        RoundData::Marking { marking_crosses } => marking_crosses
+            .get(judge_code)
+            .and_then(|jm| jm.get(&bib))
+            .and_then(|pm| pm.get(&dance))
+            .map(|&m| if m { "x".to_string() } else { "-".to_string() })
+            .unwrap_or_else(|| "&nbsp;".to_string()),
+        RoundData::DTV { dtv_ranks } => dtv_ranks
+            .get(judge_code)
+            .and_then(|jm| jm.get(&bib))
+            .and_then(|pm| pm.get(&dance))
+            .map(|&r| r.to_string())
+            .unwrap_or_else(|| "&nbsp;".to_string()),
         RoundData::WDSF { wdsf_scores } => {
-            let score = wdsf_scores.get(judge_code)
+            let score = wdsf_scores
+                .get(judge_code)
                 .and_then(|jm| jm.get(&bib))
                 .and_then(|pm| pm.get(&dance));
 

--- a/src/sources/topturnier_table.rs
+++ b/src/sources/topturnier_table.rs
@@ -420,7 +420,7 @@ pub fn to_rounds(
             let round_name = crate::i18n::get_round_name_from_id(round_id);
             if marks
                 .iter()
-                .any(|m| !crate::i18n::map_wdsf_score_type(&m.value).is_empty())
+                .any(|m| RE_SCORE.is_match(&m.value.replace(',', ".")))
             {
                 round_types.insert(round_name, true);
             }
@@ -472,12 +472,14 @@ pub fn to_rounds(
                         if let Some(judge) = mark.judge {
                             let is_cross =
                                 mark.value.to_lowercase().contains('x') || mark.value == "1";
-                            marking_crosses
+                            let e_dance_map = marking_crosses
                                 .entry(judge)
                                 .or_default()
                                 .entry(res.bib)
-                                .or_default()
-                                .insert(mark.dance, is_cross);
+                                .or_default();
+                            if is_cross || !e_dance_map.contains_key(&mark.dance) {
+                                e_dance_map.insert(mark.dance, is_cross);
+                            }
                         } else if !mark.value.is_empty()
                             && mark.value.len() > 1
                             && mark.value.chars().all(|c| c.is_ascii_digit())
@@ -552,17 +554,29 @@ pub fn to_rounds(
                                         total: 0.0,
                                     });
 
+                                let sc_with_x: Vec<f64> = RE_SCORE
+                                    .find_iter(&mark.value.replace(',', "."))
+                                    .filter_map(|m| m.as_str().parse().ok())
+                                    .collect();
+
                                 for (i, st) in score_types.iter().enumerate() {
-                                    let val = if sc.len() > i { sc[i] } else { sc[0] };
+                                    let val = if sc_with_x.len() > i {
+                                        sc_with_x[i]
+                                    } else {
+                                        sc_with_x[0]
+                                    };
                                     match *st {
                                         "technical_quality" => s.technical_quality = val,
                                         "movement_to_music" => s.movement_to_music = val,
                                         "partnering_skills" => s.partnering_skills = val,
                                         "choreography" => s.choreography = val,
-                                        "total" => s.total = val,
                                         _ => {}
                                     }
                                 }
+                                s.total = s.technical_quality
+                                    + s.movement_to_music
+                                    + s.partnering_skills
+                                    + s.choreography;
                             }
                         }
                     }

--- a/tests/44-0507_wdsfworldopenlatadult/reconstructed_ergwert.html
+++ b/tests/44-0507_wdsfworldopenlatadult/reconstructed_ergwert.html
@@ -97,744 +97,744 @@
       <td class="left"><span class="participant">Malthe Brinch Rohde / Sandra Sorensen</span><span class="affiliation">Denmark</span></td>
       <td>284</td>
       <td>F<br>5<br>4<br>3<br>2</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>9<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>0</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>-<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>9<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td class="total-cell">0.00<br>0.00<br>49<br>49<br>40</td>
+      <td>9.75|9.75<br>9.75|9.75<br>x<br>x<br>x</td>
+      <td>9.50|9.75<br>9.50|9.50<br>-<br>x<br>x</td>
+      <td>9.75|9.75<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.75|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.25|9.50<br>9.75|9.75<br>x<br>x<br>x</td>
+      <td>9.50|9.75<br>9.75|9.75<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td class="total-cell">191.50<br>191.00<br>9<br>10<br>10</td>
+      <td>9.75|9.75<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.75|9.75<br>9.75|9.75<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.75|9.75<br>9.75|9.75<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td class="total-cell">191.50<br>190.50<br>10<br>10<br>10</td>
+      <td>9.75|9.75<br>9.75|9.75<br>x<br>x<br>-</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>-</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>-</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>-</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>-</td>
+      <td>9.75|9.75<br>9.75|9.75<br>x<br>x<br>-</td>
+      <td>9.50|9.75<br>9.75|9.75<br>x<br>x<br>-</td>
+      <td>9.50|9.75<br>9.50|9.50<br>x<br>x<br>-</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>-</td>
+      <td>9.50|9.50<br>9.25|9.25<br>x<br>x<br>-</td>
+      <td class="total-cell">191.50<br>191.00<br>10<br>10<br>0</td>
+      <td>9.75|9.75<br>9.75|9.75<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.75|9.75<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.75|9.75<br>9.50|9.50<br>x<br>-<br>x</td>
+      <td>9.75|9.75<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td class="total-cell">192.00<br>188.50<br>10<br>9<br>10</td>
+      <td>9.75|9.75<br>9.75|9.75<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.75|9.75<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.75|9.75<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.75|9.75<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.75|9.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td class="total-cell">191.50<br>189.50<br>10<br>10<br>10</td>
+      <td class="total-cell">958.00<br>950.50<br>49<br>49<br>40</td>
     </tr>
     <tr>
       <td>2.</td>
       <td class="left"><span class="participant">Artur Balandin / Anna Salita</span><span class="affiliation">T.T.C. Rot-Weiß-Silber Bochum</span></td>
       <td>156</td>
       <td>F<br>5<br>4<br>3<br>2</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>9<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>-<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>9<br>0</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>-<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>9<br>9<br>10</td>
-      <td class="total-cell">0.00<br>0.00<br>48<br>48<br>40</td>
+      <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>-<br>x<br>x</td>
+      <td>9.50|9.50<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.25|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.50|9.25<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.00|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td class="total-cell">184.75<br>183.00<br>9<br>10<br>10</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td class="total-cell">184.50<br>183.50<br>10<br>10<br>10</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>-</td>
+      <td>9.25|9.50<br>9.25|9.25<br>x<br>x<br>-</td>
+      <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>-</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>-</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>-</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>-</td>
+      <td>9.50|9.25<br>9.25|9.25<br>x<br>x<br>-</td>
+      <td>9.50|9.50<br>9.25|9.25<br>x<br>-<br>-</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>-</td>
+      <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>-</td>
+      <td class="total-cell">185.50<br>183.50<br>10<br>9<br>0</td>
+      <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td class="total-cell">185.50<br>184.50<br>10<br>10<br>10</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.00|9.00<br>-<br>-<br>x</td>
+      <td class="total-cell">184.50<br>184.50<br>9<br>9<br>10</td>
+      <td class="total-cell">924.75<br>919.00<br>48<br>48<br>40</td>
     </tr>
     <tr>
       <td>3.</td>
       <td class="left"><span class="participant">Daniel Dingis / Alessia-Allegra Gigli</span><span class="affiliation">Grün-Gold-Club Bremen</span></td>
       <td>791</td>
       <td>F<br>5<br>4<br>3<br>2</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>9</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>-<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>9<br>9<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>-<br>-</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>9<br>0</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>-<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>-<br>-</td>
-      <td class="total-cell">0.00<br>0.00<br>9<br>8<br>9</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>8<br>10<br>10</td>
-      <td class="total-cell">0.00<br>0.00<br>46<br>46<br>38</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.25|8.50<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>9.00|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.00|8.00<br>9.00|9.00<br>x<br>x<br>-</td>
+      <td>8.75|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td class="total-cell">174.50<br>175.00<br>10<br>10<br>9</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>-<br>x<br>x</td>
+      <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>8.75|8.75<br>x<br>-<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td class="total-cell">176.50<br>174.50<br>9<br>9<br>10</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>-</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.75|8.75<br>9.00|9.00<br>x<br>x<br>-</td>
+      <td>8.25|8.50<br>8.25|8.25<br>x<br>x<br>-</td>
+      <td>9.00|9.25<br>9.00|9.00<br>x<br>x<br>-</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.75|8.75<br>8.50|8.50<br>x<br>-<br>-</td>
+      <td class="total-cell">175.50<br>175.00<br>10<br>9<br>0</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>-<br>x</td>
+      <td>8.75|8.75<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>-<br>-<br>-</td>
+      <td class="total-cell">175.50<br>175.50<br>9<br>8<br>9</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>-<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>9.75|9.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>-<br>x<br>x</td>
+      <td class="total-cell">177.50<br>177.50<br>8<br>10<br>10</td>
+      <td class="total-cell">879.50<br>877.50<br>46<br>46<br>38</td>
     </tr>
     <tr>
       <td>4.</td>
       <td class="left"><span class="participant">Vicenc Torremade / Megija Dana Morite</span><span class="affiliation">Latvia</span></td>
       <td>133</td>
       <td>F<br>5<br>4<br>3<br>2</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>-<br>x</td>
-      <td>0.00<br>0.00<br>x<br>-<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>9<br>8<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>9<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>-<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>-<br>-</td>
-      <td class="total-cell">0.00<br>0.00<br>9<br>8<br>0</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>8<br>10<br>9</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>-<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>9<br>9<br>10</td>
-      <td class="total-cell">0.00<br>0.00<br>44<br>45<br>39</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.75<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.75|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.25|8.50<br>8.50|8.50<br>-<br>-<br>x</td>
+      <td>8.50|8.25<br>9.00|9.00<br>x<br>-<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td class="total-cell">174.50<br>176.00<br>9<br>8<br>10</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>9.00|9.00<br>-<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td class="total-cell">174.00<br>174.50<br>9<br>10<br>10</td>
+      <td>8.50|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.50|8.75<br>9.00|9.00<br>x<br>-<br>-</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>-</td>
+      <td>8.25|8.50<br>8.50|8.50<br>x<br>x<br>-</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>-</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.25|8.50<br>8.25|8.25<br>-<br>x<br>-</td>
+      <td>9.25|9.50<br>9.00|9.00<br>x<br>x<br>-</td>
+      <td>9.00|9.25<br>9.00|9.00<br>x<br>x<br>-</td>
+      <td>9.00|9.00<br>8.75|8.75<br>x<br>-<br>-</td>
+      <td class="total-cell">176.50<br>176.00<br>9<br>8<br>0</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.25|8.25<br>-<br>x<br>x</td>
+      <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>-<br>x<br>x</td>
+      <td class="total-cell">176.00<br>176.00<br>8<br>10<br>9</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.25|8.25<br>-<br>-<br>x</td>
+      <td>9.00|9.00<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td class="total-cell">175.00<br>175.00<br>9<br>9<br>10</td>
+      <td class="total-cell">876.00<br>877.50<br>44<br>45<br>39</td>
     </tr>
     <tr>
       <td>5.</td>
       <td class="left"><span class="participant">Egor Kondratenko / Mie Lincke Funch</span><span class="affiliation">Denmark</span></td>
       <td>965</td>
       <td>F<br>5<br>4<br>3<br>2</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>-<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>-<br>-<br>-</td>
-      <td class="total-cell">0.00<br>0.00<br>8<br>8<br>0</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>-<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>9<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td class="total-cell">0.00<br>0.00<br>48<br>47<br>40</td>
+      <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.75|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td class="total-cell">174.25<br>175.00<br>10<br>10<br>10</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td class="total-cell">174.00<br>175.50<br>10<br>10<br>10</td>
+      <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.75|8.75<br>8.75|8.75<br>-<br>x<br>-</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>-</td>
+      <td>8.75|9.00<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>-<br>-</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>-</td>
+      <td>9.00|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.75|9.00<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.75|9.00<br>8.75|8.75<br>-<br>-<br>-</td>
+      <td class="total-cell">175.50<br>174.50<br>8<br>8<br>0</td>
+      <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>8.75|8.75<br>x<br>-<br>x</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td class="total-cell">174.50<br>174.50<br>10<br>9<br>10</td>
+      <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.75|9.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td class="total-cell">175.50<br>176.50<br>10<br>10<br>10</td>
+      <td class="total-cell">873.75<br>876.00<br>48<br>47<br>40</td>
     </tr>
     <tr>
       <td>6.</td>
       <td class="left"><span class="participant">Tomer Zveniatsky / Elizaveta Pustornakova</span><span class="affiliation">Israel</span></td>
       <td>165</td>
       <td>F<br>5<br>4<br>3<br>2</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>-<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>9<br>9<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>-<br>-<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td class="total-cell">0.00<br>0.00<br>8<br>9<br>0</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>-<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>9<br>9<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>-<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>8<br>9<br>9</td>
-      <td class="total-cell">0.00<br>0.00<br>44<br>46<br>39</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.75|9.00<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.00|9.50<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.50|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td class="total-cell">173.25<br>173.00<br>10<br>10<br>10</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.25|8.25<br>x<br>-<br>x</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>-<br>x<br>x</td>
+      <td class="total-cell">171.50<br>173.50<br>9<br>9<br>10</td>
+      <td>8.00|8.25<br>8.25|8.25<br>x<br>x<br>-</td>
+      <td>8.75|8.50<br>8.50|8.50<br>-<br>x<br>-</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>9.00|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>-</td>
+      <td>9.25|9.00<br>9.00|9.00<br>x<br>x<br>-</td>
+      <td>8.25|9.00<br>8.50|8.50<br>-<br>-<br>-</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>9.00|8.75<br>8.50|8.50<br>x<br>x<br>-</td>
+      <td class="total-cell">173.50<br>172.50<br>8<br>9<br>0</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.00|8.00<br>-<br>-<br>x</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td class="total-cell">172.50<br>172.50<br>9<br>9<br>10</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.75|8.75<br>-<br>x<br>x</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.25|8.25<br>-<br>x<br>-</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>-<br>x</td>
+      <td class="total-cell">172.50<br>173.50<br>8<br>9<br>9</td>
+      <td class="total-cell">863.25<br>865.00<br>44<br>46<br>39</td>
     </tr>
     <tr>
       <td>7.</td>
       <td class="left"><span class="participant">David Jenner / Elisabeth Tuigunov</span><span class="affiliation">Die Residenz Münster</span></td>
       <td>192</td>
       <td>5<br>4<br>3<br>2</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>9<br>10<br>10</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>7<br>10<br>10</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td class="total-cell">0.00<br>7<br>10<br>0</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>-<br>x</td>
-      <td class="total-cell">0.00<br>8<br>9<br>10</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>10<br>9<br>10</td>
-      <td class="total-cell">0.00<br>41<br>48<br>40</td>
+      <td>7.50|7.50<br>-<br>x<br>x</td>
+      <td>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td class="total-cell">164.50<br>9<br>10<br>10</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>-<br>x<br>x</td>
+      <td>8.75|8.75<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>-<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td class="total-cell">166.50<br>7<br>10<br>10</td>
+      <td>7.75|7.75<br>x<br>x<br>-</td>
+      <td>8.75|8.75<br>-<br>x<br>-</td>
+      <td>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>-<br>x<br>-</td>
+      <td>8.50|8.50<br>x<br>x<br>-</td>
+      <td>7.50|7.50<br>-<br>x<br>-</td>
+      <td>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>-</td>
+      <td>8.50|8.50<br>x<br>x<br>-</td>
+      <td>8.50|8.50<br>x<br>x<br>-</td>
+      <td class="total-cell">166.00<br>7<br>10<br>0</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>-<br>x<br>x</td>
+      <td>8.75|8.75<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>8.75|8.75<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>x<br>-<br>x</td>
+      <td class="total-cell">167.00<br>8<br>9<br>10</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>x<br>-<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>x<br>x<br>x</td>
+      <td class="total-cell">168.50<br>10<br>9<br>10</td>
+      <td class="total-cell">832.50<br>41<br>48<br>40</td>
     </tr>
     <tr>
       <td>8.</td>
       <td class="left"><span class="participant">Vitalii Zakharov / Tabea Louisa Thaler</span><span class="affiliation">TC Blau-Orange Wiesbaden</span></td>
       <td>851</td>
       <td>5<br>4<br>3<br>2</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>-<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>7<br>9<br>10</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>7<br>9<br>10</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>-<br>-<br>-</td>
-      <td>0.00<br>-<br>-<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>-<br>-</td>
-      <td class="total-cell">0.00<br>5<br>7<br>0</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>-<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>7<br>9<br>10</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>-<br>x</td>
-      <td>0.00<br>x<br>-<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>6<br>8<br>10</td>
-      <td class="total-cell">0.00<br>32<br>42<br>40</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>-<br>x</td>
+      <td>8.75|8.75<br>-<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td class="total-cell">162.50<br>7<br>9<br>10</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>-<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td class="total-cell">162.50<br>7<br>9<br>10</td>
+      <td>8.00|8.00<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>-</td>
+      <td>8.50|8.50<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>-<br>x<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>-</td>
+      <td>7.50|7.50<br>-<br>x<br>-</td>
+      <td>7.75|7.75<br>-<br>-<br>-</td>
+      <td>8.50|8.50<br>-<br>-<br>-</td>
+      <td>8.50|8.50<br>x<br>x<br>-</td>
+      <td>8.50|8.50<br>-<br>-<br>-</td>
+      <td class="total-cell">162.50<br>5<br>7<br>0</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>-<br>x</td>
+      <td>8.25|8.25<br>-<br>x<br>x</td>
+      <td>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td class="total-cell">162.00<br>7<br>9<br>10</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>-<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>-<br>x</td>
+      <td>8.75|8.75<br>x<br>-<br>x</td>
+      <td>8.25|8.25<br>-<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td class="total-cell">162.00<br>6<br>8<br>10</td>
+      <td class="total-cell">811.50<br>32<br>42<br>40</td>
     </tr>
     <tr>
       <td>9.</td>
       <td class="left"><span class="participant">Vinzenz Dörlitz / Albena Daskalova</span><span class="affiliation">TD Tanzsportclub Düsseldorf Rot-Weiß</span></td>
       <td>860</td>
       <td>5<br>4<br>3<br>2</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>8<br>10<br>10</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td class="total-cell">0.00<br>6<br>9<br>10</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>-<br>-</td>
-      <td class="total-cell">0.00<br>7<br>9<br>0</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td class="total-cell">0.00<br>7<br>10<br>9</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>9<br>10<br>10</td>
-      <td class="total-cell">0.00<br>37<br>48<br>39</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>7.00|7.00<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td class="total-cell">161.00<br>8<br>10<br>10</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>-<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>-<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>-<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>-<br>x<br>x</td>
+      <td class="total-cell">160.00<br>6<br>9<br>10</td>
+      <td>7.75|7.75<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>-<br>x<br>-</td>
+      <td>8.00|8.00<br>-<br>x<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>x<br>x<br>-</td>
+      <td>7.25|7.25<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>-<br>x<br>-</td>
+      <td>9.00|9.00<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>x<br>-<br>-</td>
+      <td class="total-cell">162.00<br>7<br>9<br>0</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>-<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>-<br>x<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>-<br>x<br>x</td>
+      <td>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>-</td>
+      <td class="total-cell">163.50<br>7<br>10<br>9</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>-<br>x<br>x</td>
+      <td>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td class="total-cell">162.50<br>9<br>10<br>10</td>
+      <td class="total-cell">809.00<br>37<br>48<br>39</td>
     </tr>
     <tr>
       <td>10.</td>
       <td class="left"><span class="participant">Demid Anisimov / Giuliana Domingues da Silva</span><span class="affiliation">Grün-Gold-Club Bremen</span></td>
       <td>306</td>
       <td>5<br>4<br>3<br>2<br>1</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>4<br>10<br>10<br>10</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>-<br>x<br>x</td>
-      <td class="total-cell">0.00<br>6<br>9<br>10<br>9</td>
-      <td>0.00<br>-<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>-<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>-<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>-</td>
-      <td>0.00<br>-<br>x<br>-<br>x</td>
-      <td>0.00<br>-<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td class="total-cell">0.00<br>6<br>9<br>0<br>9</td>
-      <td>0.00<br>-<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td class="total-cell">0.00<br>6<br>10<br>9<br>0</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>6<br>9<br>10<br>10</td>
-      <td class="total-cell">0.00<br>28<br>47<br>39<br>38</td>
+      <td>7.25|7.25<br>-<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>-<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>-<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>-<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>-<br>x<br>x<br>x</td>
+      <td class="total-cell">158.00<br>4<br>10<br>10<br>10</td>
+      <td>7.00|7.00<br>-<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>-<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>x<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>-<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>-<br>x<br>x</td>
+      <td class="total-cell">159.00<br>6<br>9<br>10<br>9</td>
+      <td>7.00|7.00<br>-<br>x<br>-<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>-<br>x</td>
+      <td>8.00|8.00<br>-<br>x<br>-<br>x</td>
+      <td>8.25|8.25<br>x<br>-<br>-<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>-<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>-<br>-</td>
+      <td>8.00|8.00<br>-<br>x<br>-<br>x</td>
+      <td>8.25|8.25<br>-<br>x<br>-<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>-<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>-<br>x</td>
+      <td class="total-cell">158.50<br>6<br>9<br>0<br>9</td>
+      <td>7.25|7.25<br>-<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>-<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>x<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>-</td>
+      <td>7.50|7.50<br>-<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>-<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>x<br>x<br>-<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>x<br>x<br>x<br>-</td>
+      <td class="total-cell">159.50<br>6<br>10<br>9<br>0</td>
+      <td>7.50|7.50<br>-<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>-<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>-<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>-<br>-<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td class="total-cell">162.00<br>6<br>9<br>10<br>10</td>
+      <td class="total-cell">797.00<br>28<br>47<br>39<br>38</td>
     </tr>
     <tr>
       <td>11.</td>
       <td class="left"><span class="participant">Tomasz Ruszkowski / Maria Latos</span><span class="affiliation">Poland</span></td>
       <td>561</td>
       <td>5<br>4<br>3<br>2</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td class="total-cell">0.00<br>4<br>10<br>10</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td class="total-cell">0.00<br>5<br>10<br>10</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>-<br>-<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td class="total-cell">0.00<br>5<br>9<br>0</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>-<br>x</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>x<br>-<br>x</td>
-      <td class="total-cell">0.00<br>5<br>8<br>8</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>-<br>-</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>6<br>9<br>9</td>
-      <td class="total-cell">0.00<br>25<br>46<br>37</td>
+      <td>7.00|7.00<br>-<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>8.50|8.50<br>-<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>-<br>x<br>x</td>
+      <td>7.00|7.00<br>-<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>-<br>x<br>x</td>
+      <td class="total-cell">158.00<br>4<br>10<br>10</td>
+      <td>7.00|7.00<br>-<br>x<br>x</td>
+      <td>8.00|8.00<br>-<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>-<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>-<br>x<br>x</td>
+      <td class="total-cell">158.50<br>5<br>10<br>10</td>
+      <td>7.00|7.00<br>-<br>x<br>-</td>
+      <td>8.00|8.00<br>-<br>-<br>-</td>
+      <td>8.25|8.25<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>-<br>x<br>-</td>
+      <td>7.50|7.50<br>-<br>x<br>-</td>
+      <td>7.25|7.25<br>-<br>x<br>-</td>
+      <td>8.50|8.50<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>x<br>x<br>-</td>
+      <td class="total-cell">157.50<br>5<br>9<br>0</td>
+      <td>7.00|7.00<br>-<br>x<br>-</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x</td>
+      <td>7.25|7.25<br>-<br>x<br>x</td>
+      <td>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>-<br>x</td>
+      <td>8.25|8.25<br>-<br>x<br>-</td>
+      <td>8.25|8.25<br>x<br>-<br>x</td>
+      <td class="total-cell">158.00<br>5<br>8<br>8</td>
+      <td>7.25|7.25<br>-<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x</td>
+      <td>7.00|7.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>-<br>-<br>-</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td class="total-cell">157.00<br>6<br>9<br>9</td>
+      <td class="total-cell">789.00<br>25<br>46<br>37</td>
     </tr>
     <tr>
       <td>12.</td>
       <td class="left"><span class="participant">Justin Lauer / Rita Schumichin</span><span class="affiliation">TSC Saltatio Neustadt im TV 1860 Mußbach</span></td>
       <td>331</td>
       <td>5<br>4<br>3<br>2</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>-<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>6<br>9<br>10</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>-<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>-<br>x</td>
-      <td class="total-cell">0.00<br>6<br>7<br>10</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>-<br>-</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td class="total-cell">0.00<br>7<br>9<br>0</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>7<br>10<br>10</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>4<br>10<br>10</td>
-      <td class="total-cell">0.00<br>30<br>45<br>40</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>-<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x</td>
+      <td>7.25|7.25<br>-<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>-<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td class="total-cell">157.50<br>6<br>9<br>10</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>-<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x</td>
+      <td>7.00|7.00<br>-<br>-<br>x</td>
+      <td>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>-<br>-<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>-<br>x</td>
+      <td class="total-cell">157.00<br>6<br>7<br>10</td>
+      <td>7.75|7.75<br>x<br>x<br>-</td>
+      <td>7.50|7.50<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>-<br>x<br>-</td>
+      <td>8.25|8.25<br>x<br>x<br>-</td>
+      <td>7.50|7.50<br>x<br>x<br>-</td>
+      <td>7.25|7.25<br>x<br>x<br>-</td>
+      <td>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>x<br>x<br>-</td>
+      <td>7.75|7.75<br>-<br>-<br>-</td>
+      <td>8.25|8.25<br>-<br>x<br>-</td>
+      <td class="total-cell">158.50<br>7<br>9<br>0</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>-<br>x<br>x</td>
+      <td>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td class="total-cell">158.00<br>7<br>10<br>10</td>
+      <td>7.50|7.50<br>-<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>-<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>7.25|7.25<br>-<br>x<br>x</td>
+      <td>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>-<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td class="total-cell">157.50<br>4<br>10<br>10</td>
+      <td class="total-cell">788.50<br>30<br>45<br>40</td>
     </tr>
     <tr>
       <td>13.</td>

--- a/tests/44-0507_wdsfworldopenlatadult/tabges.json
+++ b/tests/44-0507_wdsfworldopenlatadult/tabges.json
@@ -17079,35 +17079,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "156": {
@@ -17116,35 +17116,35 @@
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "165": {
@@ -17153,35 +17153,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "192": {
@@ -17190,35 +17190,35 @@
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "284": {
@@ -17227,35 +17227,35 @@
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.5
             }
           },
           "306": {
@@ -17264,35 +17264,35 @@
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 7.0,
               "partnering_skills": 0.0,
               "choreography": 7.0,
-              "total": 0.0
+              "total": 14.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 7.0,
               "partnering_skills": 0.0,
               "choreography": 7.0,
-              "total": 0.0
+              "total": 14.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             }
           },
           "331": {
@@ -17301,35 +17301,35 @@
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             }
           },
           "561": {
@@ -17338,35 +17338,35 @@
               "movement_to_music": 7.0,
               "partnering_skills": 0.0,
               "choreography": 7.0,
-              "total": 0.0
+              "total": 14.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 7.0,
               "partnering_skills": 0.0,
               "choreography": 7.0,
-              "total": 0.0
+              "total": 14.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 7.0,
               "partnering_skills": 0.0,
               "choreography": 7.0,
-              "total": 0.0
+              "total": 14.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 7.0,
               "partnering_skills": 0.0,
               "choreography": 7.0,
-              "total": 0.0
+              "total": 14.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             }
           },
           "791": {
@@ -17375,35 +17375,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "851": {
@@ -17412,35 +17412,35 @@
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "860": {
@@ -17449,35 +17449,35 @@
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "965": {
@@ -17486,35 +17486,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           }
         },
@@ -17525,35 +17525,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "156": {
@@ -17562,35 +17562,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "ChaChaCha": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Rumba": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "PasoDoble": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Jive": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "165": {
@@ -17599,35 +17599,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "PasoDoble": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "192": {
@@ -17636,35 +17636,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "284": {
@@ -17673,35 +17673,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "ChaChaCha": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Rumba": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "PasoDoble": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Jive": {
               "technical_quality": 9.75,
               "movement_to_music": 0.0,
               "partnering_skills": 9.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.5
             }
           },
           "306": {
@@ -17710,35 +17710,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "ChaChaCha": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Rumba": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "PasoDoble": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Jive": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "331": {
@@ -17747,35 +17747,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "ChaChaCha": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "Rumba": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "PasoDoble": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Jive": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             }
           },
           "561": {
@@ -17784,35 +17784,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "ChaChaCha": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Rumba": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "PasoDoble": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Jive": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "791": {
@@ -17821,35 +17821,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "851": {
@@ -17858,35 +17858,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "ChaChaCha": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "PasoDoble": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Jive": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "860": {
@@ -17895,35 +17895,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "ChaChaCha": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Rumba": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "PasoDoble": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Jive": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "965": {
@@ -17932,35 +17932,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           }
         },
@@ -17971,35 +17971,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Jive": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "156": {
@@ -18008,35 +18008,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "165": {
@@ -18045,35 +18045,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "192": {
@@ -18082,35 +18082,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "284": {
@@ -18119,35 +18119,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "ChaChaCha": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Rumba": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "PasoDoble": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Jive": {
               "technical_quality": 9.75,
               "movement_to_music": 0.0,
               "partnering_skills": 9.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.5
             }
           },
           "306": {
@@ -18156,35 +18156,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "ChaChaCha": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Rumba": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "PasoDoble": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Jive": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "331": {
@@ -18193,35 +18193,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "ChaChaCha": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Rumba": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "PasoDoble": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Jive": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "561": {
@@ -18230,35 +18230,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "PasoDoble": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Jive": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "791": {
@@ -18267,35 +18267,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "851": {
@@ -18304,35 +18304,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Rumba": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "PasoDoble": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "860": {
@@ -18341,35 +18341,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "ChaChaCha": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Rumba": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "PasoDoble": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Jive": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "965": {
@@ -18378,35 +18378,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           }
         },
@@ -18417,35 +18417,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "PasoDoble": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "156": {
@@ -18454,35 +18454,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "165": {
@@ -18491,35 +18491,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "192": {
@@ -18528,35 +18528,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "ChaChaCha": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Rumba": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "PasoDoble": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Jive": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "284": {
@@ -18565,35 +18565,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "ChaChaCha": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Rumba": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "PasoDoble": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Jive": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "306": {
@@ -18602,35 +18602,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "ChaChaCha": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Rumba": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "PasoDoble": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Jive": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "331": {
@@ -18639,35 +18639,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "ChaChaCha": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Rumba": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "PasoDoble": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Jive": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "561": {
@@ -18676,35 +18676,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "ChaChaCha": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Rumba": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "PasoDoble": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Jive": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "791": {
@@ -18713,35 +18713,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "851": {
@@ -18750,35 +18750,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "ChaChaCha": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Rumba": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "PasoDoble": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Jive": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "860": {
@@ -18787,35 +18787,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "ChaChaCha": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Rumba": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "PasoDoble": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Jive": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "965": {
@@ -18824,35 +18824,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "PasoDoble": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           }
         },
@@ -18863,35 +18863,35 @@
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "156": {
@@ -18900,35 +18900,35 @@
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "165": {
@@ -18937,35 +18937,35 @@
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "192": {
@@ -18974,35 +18974,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "284": {
@@ -19011,35 +19011,35 @@
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "306": {
@@ -19048,35 +19048,35 @@
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "331": {
@@ -19085,35 +19085,35 @@
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "561": {
@@ -19122,35 +19122,35 @@
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             }
           },
           "791": {
@@ -19159,35 +19159,35 @@
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "851": {
@@ -19196,35 +19196,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "860": {
@@ -19233,35 +19233,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "965": {
@@ -19270,35 +19270,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           }
         },
@@ -19309,35 +19309,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "156": {
@@ -19346,35 +19346,35 @@
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "165": {
@@ -19383,35 +19383,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "192": {
@@ -19420,35 +19420,35 @@
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             }
           },
           "284": {
@@ -19457,35 +19457,35 @@
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "306": {
@@ -19494,35 +19494,35 @@
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "331": {
@@ -19531,35 +19531,35 @@
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 7.0,
               "partnering_skills": 0.0,
               "choreography": 7.0,
-              "total": 0.0
+              "total": 14.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             }
           },
           "561": {
@@ -19568,35 +19568,35 @@
               "movement_to_music": 7.0,
               "partnering_skills": 0.0,
               "choreography": 7.0,
-              "total": 0.0
+              "total": 14.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 7.0,
               "partnering_skills": 0.0,
               "choreography": 7.0,
-              "total": 0.0
+              "total": 14.0
             }
           },
           "791": {
@@ -19605,35 +19605,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "851": {
@@ -19642,35 +19642,35 @@
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             }
           },
           "860": {
@@ -19679,35 +19679,35 @@
               "movement_to_music": 7.0,
               "partnering_skills": 0.0,
               "choreography": 7.0,
-              "total": 0.0
+              "total": 14.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             }
           },
           "965": {
@@ -19716,35 +19716,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           }
         },
@@ -19755,35 +19755,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "156": {
@@ -19792,35 +19792,35 @@
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "165": {
@@ -19829,35 +19829,35 @@
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "192": {
@@ -19866,35 +19866,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "284": {
@@ -19903,35 +19903,35 @@
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "306": {
@@ -19940,35 +19940,35 @@
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "331": {
@@ -19977,35 +19977,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "561": {
@@ -20014,35 +20014,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "791": {
@@ -20051,35 +20051,35 @@
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "851": {
@@ -20088,35 +20088,35 @@
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "860": {
@@ -20125,35 +20125,35 @@
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "965": {
@@ -20162,35 +20162,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           }
         },
@@ -20201,35 +20201,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "156": {
@@ -20238,35 +20238,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "ChaChaCha": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Rumba": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "PasoDoble": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Jive": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "165": {
@@ -20275,35 +20275,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "ChaChaCha": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Rumba": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "PasoDoble": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Jive": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "192": {
@@ -20312,35 +20312,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "ChaChaCha": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "PasoDoble": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Jive": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "284": {
@@ -20349,35 +20349,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.5
             },
             "ChaChaCha": {
               "technical_quality": 9.75,
               "movement_to_music": 0.0,
               "partnering_skills": 9.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.5
             },
             "Rumba": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "PasoDoble": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "306": {
@@ -20386,35 +20386,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "PasoDoble": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Jive": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "331": {
@@ -20423,35 +20423,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "ChaChaCha": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Rumba": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "PasoDoble": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Jive": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "561": {
@@ -20460,35 +20460,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "ChaChaCha": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Rumba": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "PasoDoble": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Jive": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "791": {
@@ -20497,35 +20497,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "851": {
@@ -20534,35 +20534,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "PasoDoble": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "860": {
@@ -20571,35 +20571,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Rumba": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "965": {
@@ -20608,35 +20608,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "ChaChaCha": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             }
           }
         },
@@ -20647,35 +20647,35 @@
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "156": {
@@ -20684,35 +20684,35 @@
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "165": {
@@ -20721,35 +20721,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "192": {
@@ -20758,35 +20758,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "284": {
@@ -20795,35 +20795,35 @@
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "306": {
@@ -20832,35 +20832,35 @@
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "331": {
@@ -20869,35 +20869,35 @@
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "561": {
@@ -20906,35 +20906,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "791": {
@@ -20943,35 +20943,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.5
             }
           },
           "851": {
@@ -20980,35 +20980,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "860": {
@@ -21017,35 +21017,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "965": {
@@ -21054,35 +21054,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.5
             }
           }
         },
@@ -21093,35 +21093,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "156": {
@@ -21130,35 +21130,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Jive": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "165": {
@@ -21167,35 +21167,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "192": {
@@ -21204,35 +21204,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "284": {
@@ -21241,35 +21241,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "ChaChaCha": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Rumba": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "PasoDoble": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Jive": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "306": {
@@ -21278,35 +21278,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "ChaChaCha": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Rumba": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "PasoDoble": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Jive": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "331": {
@@ -21315,35 +21315,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "ChaChaCha": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Rumba": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "PasoDoble": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Jive": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "561": {
@@ -21352,35 +21352,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "ChaChaCha": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Rumba": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "PasoDoble": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Jive": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "791": {
@@ -21389,35 +21389,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "851": {
@@ -21426,35 +21426,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "PasoDoble": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "860": {
@@ -21463,35 +21463,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "ChaChaCha": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Rumba": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "PasoDoble": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "965": {
@@ -21500,35 +21500,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           }
         }
@@ -21553,35 +21553,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.25
             },
             "PasoDoble": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "156": {
@@ -21590,35 +21590,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "ChaChaCha": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Rumba": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "PasoDoble": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Jive": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "165": {
@@ -21627,35 +21627,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "ChaChaCha": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Rumba": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.25
             },
             "PasoDoble": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Jive": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "284": {
@@ -21664,35 +21664,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.5
             },
             "ChaChaCha": {
               "technical_quality": 9.75,
               "movement_to_music": 0.0,
               "partnering_skills": 9.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.5
             },
             "Rumba": {
               "technical_quality": 9.75,
               "movement_to_music": 0.0,
               "partnering_skills": 9.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.5
             },
             "PasoDoble": {
               "technical_quality": 9.75,
               "movement_to_music": 0.0,
               "partnering_skills": 9.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.5
             },
             "Jive": {
               "technical_quality": 9.75,
               "movement_to_music": 0.0,
               "partnering_skills": 9.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.5
             }
           },
           "791": {
@@ -21701,35 +21701,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "965": {
@@ -21738,35 +21738,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             }
           }
         },
@@ -21777,35 +21777,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.25
             },
             "ChaChaCha": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.25
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "156": {
@@ -21814,35 +21814,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "ChaChaCha": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Rumba": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.75
             },
             "PasoDoble": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Jive": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "165": {
@@ -21851,35 +21851,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.25
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "284": {
@@ -21888,35 +21888,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.25
             },
             "ChaChaCha": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Rumba": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "PasoDoble": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Jive": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "791": {
@@ -21925,35 +21925,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "965": {
@@ -21962,35 +21962,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           }
         },
@@ -22001,35 +22001,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "ChaChaCha": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "156": {
@@ -22038,35 +22038,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "ChaChaCha": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Rumba": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "PasoDoble": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Jive": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "165": {
@@ -22075,35 +22075,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "PasoDoble": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "284": {
@@ -22112,35 +22112,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.5
             },
             "ChaChaCha": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Rumba": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "PasoDoble": {
               "technical_quality": 9.75,
               "movement_to_music": 0.0,
               "partnering_skills": 9.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.5
             },
             "Jive": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "791": {
@@ -22149,35 +22149,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "965": {
@@ -22186,35 +22186,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           }
         },
@@ -22225,35 +22225,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Rumba": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.75
             },
             "PasoDoble": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "156": {
@@ -22262,35 +22262,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "165": {
@@ -22299,35 +22299,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.25
             },
             "ChaChaCha": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "284": {
@@ -22336,35 +22336,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "ChaChaCha": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Rumba": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "PasoDoble": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Jive": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "791": {
@@ -22373,35 +22373,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "965": {
@@ -22410,35 +22410,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Rumba": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "PasoDoble": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Jive": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           }
         },
@@ -22449,35 +22449,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "156": {
@@ -22486,35 +22486,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "ChaChaCha": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Rumba": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "PasoDoble": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Jive": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "165": {
@@ -22523,35 +22523,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.75
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "284": {
@@ -22560,35 +22560,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "ChaChaCha": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Rumba": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "PasoDoble": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Jive": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "791": {
@@ -22597,35 +22597,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "965": {
@@ -22634,35 +22634,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.75
             },
             "PasoDoble": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           }
         },
@@ -22673,35 +22673,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.25
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "156": {
@@ -22710,35 +22710,35 @@
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.25
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "165": {
@@ -22747,35 +22747,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "284": {
@@ -22784,35 +22784,35 @@
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.25
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "791": {
@@ -22821,35 +22821,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 16.75
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 16.75
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "965": {
@@ -22858,35 +22858,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           }
         },
@@ -22897,35 +22897,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 16.75
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 16.75
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "156": {
@@ -22934,35 +22934,35 @@
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.75
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "165": {
@@ -22971,35 +22971,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 17.75
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.25
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "284": {
@@ -23008,35 +23008,35 @@
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 18.75
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.25
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.5
             }
           },
           "791": {
@@ -23045,35 +23045,35 @@
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.25
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.25
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "965": {
@@ -23082,35 +23082,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 17.75
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           }
         },
@@ -23121,35 +23121,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.75
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 18.75
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "156": {
@@ -23158,35 +23158,35 @@
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.75
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "165": {
@@ -23195,35 +23195,35 @@
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 18.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 17.25
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "284": {
@@ -23232,35 +23232,35 @@
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.25
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.25
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.5
             }
           },
           "791": {
@@ -23269,35 +23269,35 @@
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 17.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "965": {
@@ -23306,35 +23306,35 @@
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.75
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             }
           }
         },
@@ -23345,35 +23345,35 @@
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.25
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "156": {
@@ -23382,35 +23382,35 @@
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "165": {
@@ -23419,35 +23419,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.25
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "284": {
@@ -23456,35 +23456,35 @@
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "791": {
@@ -23493,35 +23493,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.25
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "965": {
@@ -23530,35 +23530,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 17.75
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           }
         },
@@ -23569,35 +23569,35 @@
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "156": {
@@ -23606,35 +23606,35 @@
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.25
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "165": {
@@ -23643,35 +23643,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.75
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "284": {
@@ -23680,35 +23680,35 @@
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "791": {
@@ -23717,35 +23717,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.25
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "965": {
@@ -23754,35 +23754,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "ChaChaCha": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Rumba": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 17.75
             },
             "PasoDoble": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Jive": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           }
         }

--- a/tests/75-0607_wdsfworldopenstdadult/reconstructed_ergwert.html
+++ b/tests/75-0607_wdsfworldopenstdadult/reconstructed_ergwert.html
@@ -97,744 +97,744 @@
       <td class="left"><span class="participant">Dmitri Kolobov / Signe Busk</span><span class="affiliation">Denmark</span></td>
       <td>575</td>
       <td>F<br>5<br>4<br>3<br>2</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>0</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>9<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td class="total-cell">0.00<br>0.00<br>49<br>50<br>40</td>
+      <td>9.00|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.50|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.25|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.75|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.75|9.75<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td class="total-cell">188.00<br>186.50<br>10<br>10<br>10</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>-</td>
+      <td>9.50|9.50<br>9.25|9.25<br>x<br>x<br>-</td>
+      <td>9.50|9.75<br>9.50|9.50<br>x<br>x<br>-</td>
+      <td>9.50|9.50<br>9.25|9.25<br>x<br>x<br>-</td>
+      <td>9.25|9.00<br>9.00|9.00<br>x<br>x<br>-</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>-</td>
+      <td>9.75|9.50<br>9.50|9.50<br>x<br>x<br>-</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>-</td>
+      <td>9.75|9.75<br>9.75|9.75<br>x<br>x<br>-</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>-</td>
+      <td class="total-cell">189.25<br>187.50<br>10<br>10<br>0</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td class="total-cell">187.50<br>186.00<br>10<br>10<br>10</td>
+      <td>9.50|9.50<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.00|9.00<br>-<br>x<br>x</td>
+      <td>9.75|9.75<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.75|9.75<br>9.75|9.75<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td class="total-cell">190.00<br>187.00<br>9<br>10<br>10</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
+      <td>9.75|9.75<br>9.75|9.75<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td class="total-cell">189.00<br>187.50<br>10<br>10<br>10</td>
+      <td class="total-cell">943.75<br>934.50<br>49<br>50<br>40</td>
     </tr>
     <tr>
       <td>2.</td>
       <td class="left"><span class="participant">Yahor Boldysh / Irina Averina</span><span class="affiliation">TSC Excelsior Dresden</span></td>
       <td>645</td>
       <td>F<br>5<br>4<br>3<br>2</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>0</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>9</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td class="total-cell">0.00<br>0.00<br>50<br>50<br>39</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|8.75<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td class="total-cell">177.50<br>177.50<br>10<br>10<br>10</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>9.00|9.00<br>8.50|8.50<br>x<br>x<br>-</td>
+      <td>9.00|9.25<br>9.25|9.25<br>x<br>x<br>-</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.75|9.00<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>-</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>-</td>
+      <td>8.50|8.75<br>8.50|8.50<br>x<br>x<br>-</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td class="total-cell">177.75<br>176.50<br>10<br>10<br>0</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td class="total-cell">177.00<br>176.00<br>10<br>10<br>10</td>
+      <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td class="total-cell">179.50<br>177.50<br>10<br>10<br>9</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td class="total-cell">176.00<br>175.50<br>10<br>10<br>10</td>
+      <td class="total-cell">887.75<br>883.00<br>50<br>50<br>39</td>
     </tr>
     <tr>
       <td>3.</td>
       <td class="left"><span class="participant">Ilia Rotar / Silvia Susanne Barjabin</span><span class="affiliation">Estonia</span></td>
       <td>427</td>
       <td>F<br>5<br>4<br>3<br>2</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>0</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>-<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>9<br>10</td>
-      <td class="total-cell">0.00<br>0.00<br>50<br>49<br>40</td>
+      <td>8.75|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>8.75|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td class="total-cell">174.75<br>174.00<br>10<br>10<br>10</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.50|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>9.00|8.75<br>9.00|9.00<br>x<br>x<br>-</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>-</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.25|8.50<br>8.50|8.50<br>x<br>x<br>-</td>
+      <td>9.00|9.00<br>9.25|9.25<br>x<br>x<br>-</td>
+      <td>8.75|8.50<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.50|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td class="total-cell">173.25<br>175.50<br>10<br>10<br>0</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td class="total-cell">175.50<br>174.50<br>10<br>10<br>10</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.25|9.25<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td class="total-cell">174.50<br>175.50<br>10<br>10<br>10</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.25|8.25<br>x<br>-<br>x</td>
+      <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
+      <td class="total-cell">176.00<br>175.00<br>10<br>9<br>10</td>
+      <td class="total-cell">874.00<br>874.50<br>50<br>49<br>40</td>
     </tr>
     <tr>
       <td>4.</td>
       <td class="left"><span class="participant">Iliya Dobrev / Elizaveta Basiuk</span><span class="affiliation">Bulgaria</span></td>
       <td>716</td>
       <td>F<br>5<br>4<br>3<br>2<br>1</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>0.00<br>-<br>x<br>-<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>0.00<br>-<br>x<br>-<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>8<br>10<br>0<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>-<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>-<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>-</td>
-      <td class="total-cell">0.00<br>0.00<br>8<br>10<br>10<br>0</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>8<br>9</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>-<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>8<br>9<br>10<br>10</td>
-      <td class="total-cell">0.00<br>0.00<br>44<br>49<br>38<br>39</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td>8.25|8.00<br>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>8.75|8.50<br>8.75|8.75<br>x<br>x<br>x<br>x</td>
+      <td>8.25|8.00<br>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x<br>x</td>
+      <td class="total-cell">166.25<br>166.00<br>10<br>10<br>10<br>10</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>-<br>x</td>
+      <td>8.50|8.75<br>8.50|8.50<br>x<br>x<br>-<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>-<br>x</td>
+      <td>8.00|8.00<br>7.75|7.75<br>-<br>x<br>-<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>-<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>-<br>x<br>-<br>x</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>-<br>x</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-<br>x</td>
+      <td>8.25|8.00<br>7.75|7.75<br>x<br>x<br>-<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>-<br>x</td>
+      <td class="total-cell">167.00<br>165.00<br>8<br>10<br>0<br>10</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x<br>-</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x<br>-</td>
+      <td>8.50|8.50<br>8.25|8.25<br>-<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>7.75|7.75<br>x<br>x<br>x<br>-</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>8.50|8.50<br>x<br>x<br>x<br>-</td>
+      <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x<br>-</td>
+      <td>7.75|7.75<br>7.75|7.75<br>-<br>x<br>x<br>-</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x<br>-</td>
+      <td class="total-cell">166.00<br>167.00<br>8<br>10<br>10<br>0</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>-<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>-<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td>9.00|9.00<br>8.50|8.50<br>x<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x<br>x</td>
+      <td class="total-cell">168.00<br>166.50<br>10<br>10<br>8<br>9</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>-<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>7.50|7.50<br>x<br>-<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>-<br>x<br>x<br>x</td>
+      <td class="total-cell">167.50<br>164.00<br>8<br>9<br>10<br>10</td>
+      <td class="total-cell">834.75<br>828.50<br>44<br>49<br>38<br>39</td>
     </tr>
     <tr>
       <td>5.</td>
       <td class="left"><span class="participant">Xu Ziyin / Yan Xinru</span><span class="affiliation">P.R. China</span></td>
       <td>462</td>
       <td>F<br>5<br>4<br>3<br>2</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>-<br>-</td>
-      <td>0.00<br>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>-<br>x<br>-</td>
-      <td class="total-cell">0.00<br>0.00<br>7<br>9<br>0</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>-<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>9<br>9<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>9<br>10<br>10</td>
-      <td class="total-cell">0.00<br>0.00<br>45<br>48<br>40</td>
+      <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.25|8.50<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.50|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.25|8.50<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.25|8.00<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td class="total-cell">165.50<br>163.50<br>10<br>10<br>10</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>-</td>
+      <td>8.50|8.50<br>8.25|8.25<br>x<br>x<br>-</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>-<br>-</td>
+      <td>8.25|8.25<br>8.00|8.00<br>-<br>x<br>-</td>
+      <td>8.50|8.25<br>8.25|8.25<br>x<br>x<br>-</td>
+      <td>8.50|8.50<br>8.00|8.00<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>8.25|8.25<br>-<br>x<br>-</td>
+      <td>8.50|8.50<br>8.25|8.25<br>x<br>x<br>-</td>
+      <td>8.50|8.50<br>8.25|8.25<br>-<br>x<br>-</td>
+      <td class="total-cell">167.75<br>163.50<br>7<br>9<br>0</td>
+      <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>7.75|7.75<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td class="total-cell">165.00<br>162.00<br>10<br>10<br>10</td>
+      <td>8.00|8.00<br>7.75|7.75<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>-<br>x</td>
+      <td>8.50|8.50<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>-<br>x<br>x</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td class="total-cell">165.00<br>163.50<br>9<br>9<br>10</td>
+      <td>8.00|8.00<br>7.75|7.75<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>-<br>x<br>x</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td class="total-cell">165.00<br>163.00<br>9<br>10<br>10</td>
+      <td class="total-cell">828.25<br>815.50<br>45<br>48<br>40</td>
     </tr>
     <tr>
       <td>6.</td>
       <td class="left"><span class="participant">Erik Kem / Viktoria Grushevskaja</span><span class="affiliation">TTC München</span></td>
       <td>250</td>
       <td>F<br>5<br>4<br>3<br>2</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>0.00<br>x<br>x<br>-</td>
-      <td class="total-cell">0.00<br>0.00<br>9<br>10<br>0</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>9<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>0.00<br>10<br>10<br>10</td>
-      <td class="total-cell">0.00<br>0.00<br>48<br>50<br>40</td>
+      <td>8.00|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.25|8.00<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.25|8.00<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.25|8.50<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.25|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.25|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td class="total-cell">165.00<br>164.50<br>10<br>10<br>10</td>
+      <td>8.00|8.25<br>8.25|8.25<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>-</td>
+      <td>7.75|8.00<br>8.00|8.00<br>-<br>x<br>-</td>
+      <td>8.00|8.00<br>7.75|7.75<br>x<br>x<br>-</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>-</td>
+      <td>8.50|8.50<br>8.25|8.25<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>8.25|8.25<br>x<br>x<br>-</td>
+      <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>-</td>
+      <td>8.25|8.50<br>8.25|8.25<br>x<br>x<br>-</td>
+      <td class="total-cell">164.75<br>164.00<br>9<br>10<br>0</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>7.75|7.75<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>9.00|9.00<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>-<br>x<br>x</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td class="total-cell">165.50<br>165.50<br>9<br>10<br>10</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td class="total-cell">165.00<br>165.00<br>10<br>10<br>10</td>
+      <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
+      <td class="total-cell">164.50<br>164.00<br>10<br>10<br>10</td>
+      <td class="total-cell">824.75<br>823.00<br>48<br>50<br>40</td>
     </tr>
     <tr>
       <td>7.</td>
       <td class="left"><span class="participant">Marcel Mijalski / Julia Wojteczek</span><span class="affiliation">Poland</span></td>
       <td>708</td>
       <td>5<br>4<br>3<br>2<br>1</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>9<br>10<br>10<br>10</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>-<br>x<br>-<br>-</td>
-      <td>0.00<br>-<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>-</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>-<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>-<br>-<br>x</td>
-      <td class="total-cell">0.00<br>7<br>9<br>0<br>8</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td class="total-cell">0.00<br>8<br>10<br>10<br>0</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>9<br>9<br>10<br>9</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>8<br>10<br>10<br>9</td>
-      <td class="total-cell">0.00<br>41<br>48<br>40<br>36</td>
+      <td>8.50|8.50<br>x<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td class="total-cell">161.00<br>9<br>10<br>10<br>10</td>
+      <td>8.50|8.50<br>x<br>x<br>-<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>-<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>-<br>-</td>
+      <td>7.75|7.75<br>-<br>x<br>-<br>x</td>
+      <td>8.75|8.75<br>x<br>x<br>-<br>-</td>
+      <td>7.75|7.75<br>x<br>x<br>-<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>-<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>-<br>x</td>
+      <td>7.00|7.00<br>-<br>x<br>-<br>x</td>
+      <td>8.25|8.25<br>x<br>-<br>-<br>x</td>
+      <td class="total-cell">161.00<br>7<br>9<br>0<br>8</td>
+      <td>8.50|8.50<br>x<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>x<br>x<br>x<br>-</td>
+      <td>7.75|7.75<br>-<br>x<br>x<br>-</td>
+      <td>7.50|7.50<br>x<br>x<br>x<br>-</td>
+      <td>8.75|8.75<br>x<br>x<br>x<br>-</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>x<br>x<br>x<br>-</td>
+      <td>7.25|7.25<br>-<br>x<br>x<br>-</td>
+      <td>8.50|8.50<br>x<br>x<br>x<br>-</td>
+      <td class="total-cell">161.00<br>8<br>10<br>10<br>0</td>
+      <td>8.50|8.50<br>x<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>8.75|8.75<br>x<br>x<br>x<br>-</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td>6.25|6.25<br>-<br>-<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td class="total-cell">159.50<br>9<br>9<br>10<br>9</td>
+      <td>8.50|8.50<br>x<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x<br>-</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>-<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td class="total-cell">161.50<br>8<br>10<br>10<br>9</td>
+      <td class="total-cell">804.00<br>41<br>48<br>40<br>36</td>
     </tr>
     <tr>
       <td>8.</td>
       <td class="left"><span class="participant">Joshua Khadjeh-Nouri / Jadzia Khadjeh-Nouri</span><span class="affiliation">Tanzsportclub Astoria Norderstedt</span></td>
       <td>958</td>
       <td>5<br>4<br>3<br>2</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>9<br>10<br>10</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td class="total-cell">0.00<br>9<br>10<br>0</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>8<br>10<br>10</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td class="total-cell">0.00<br>9<br>10<br>10</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>8<br>10<br>9</td>
-      <td class="total-cell">0.00<br>43<br>50<br>39</td>
+      <td>7.25|7.25<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>-<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td class="total-cell">157.00<br>9<br>10<br>10</td>
+      <td>7.25|7.25<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>x<br>x<br>-</td>
+      <td>8.50|8.50<br>x<br>x<br>-</td>
+      <td>7.50|7.50<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>-</td>
+      <td>7.75|7.75<br>-<br>x<br>-</td>
+      <td>8.25|8.25<br>x<br>x<br>-</td>
+      <td>7.50|7.50<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>x<br>x<br>-</td>
+      <td class="total-cell">158.50<br>9<br>10<br>0</td>
+      <td>7.50|7.50<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>-<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td class="total-cell">157.50<br>8<br>10<br>10</td>
+      <td>7.25|7.25<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>-<br>x<br>x</td>
+      <td class="total-cell">156.50<br>9<br>10<br>10</td>
+      <td>7.25|7.25<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.50|8.50<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td class="total-cell">157.50<br>8<br>10<br>9</td>
+      <td class="total-cell">787.00<br>43<br>50<br>39</td>
     </tr>
     <tr>
       <td>9.</td>
       <td class="left"><span class="participant">Samuele Pugliese / Federica Stavale</span><span class="affiliation">Italy</span></td>
       <td>876</td>
       <td>5<br>4<br>3<br>2<br>1</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>-<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>5<br>10<br>9<br>10</td>
-      <td>0.00<br>-<br>x<br>-<br>x</td>
-      <td>0.00<br>-<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>-<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>-<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>-<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td class="total-cell">0.00<br>6<br>9<br>0<br>10</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>-<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>x<br>-</td>
-      <td class="total-cell">0.00<br>4<br>9<br>10<br>0</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>5<br>10<br>9<br>10</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>7<br>9<br>10<br>10</td>
-      <td class="total-cell">0.00<br>27<br>47<br>38<br>40</td>
+      <td>7.00|7.00<br>x<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>-<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>-<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x<br>x</td>
+      <td class="total-cell">151.00<br>5<br>10<br>9<br>10</td>
+      <td>7.25|7.25<br>-<br>x<br>-<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>-<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>-<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>-<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>-<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>-<br>x</td>
+      <td>8.00|8.00<br>-<br>x<br>-<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>-<br>x</td>
+      <td>7.75|7.75<br>x<br>-<br>-<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>-<br>x</td>
+      <td class="total-cell">153.00<br>6<br>9<br>0<br>10</td>
+      <td>7.25|7.25<br>x<br>x<br>x<br>-</td>
+      <td>7.75|7.75<br>-<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>-</td>
+      <td>7.25|7.25<br>-<br>x<br>x<br>-</td>
+      <td>7.50|7.50<br>-<br>x<br>x<br>-</td>
+      <td>7.50|7.50<br>-<br>-<br>x<br>-</td>
+      <td>7.75|7.75<br>-<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>-</td>
+      <td>7.50|7.50<br>x<br>x<br>x<br>-</td>
+      <td>7.25|7.25<br>-<br>x<br>x<br>-</td>
+      <td class="total-cell">151.50<br>4<br>9<br>10<br>0</td>
+      <td>7.25|7.25<br>-<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>-<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>-<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>-<br>x<br>x<br>x</td>
+      <td class="total-cell">152.50<br>5<br>10<br>9<br>10</td>
+      <td>7.00|7.00<br>-<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>-<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x<br>x</td>
+      <td class="total-cell">153.50<br>7<br>9<br>10<br>10</td>
+      <td class="total-cell">761.50<br>27<br>47<br>38<br>40</td>
     </tr>
     <tr>
       <td>10.</td>
       <td class="left"><span class="participant">Anton Peredery / Taisija Bicihina</span><span class="affiliation">Latvia</span></td>
       <td>465</td>
       <td>5<br>4<br>3<br>2<br>1</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>7<br>10<br>10<br>10</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>-<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>-<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>-<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>-</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>-<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td class="total-cell">0.00<br>7<br>9<br>0<br>9</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>x<br>-</td>
-      <td class="total-cell">0.00<br>6<br>10<br>9<br>0</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>6<br>6<br>10<br>10</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>5<br>10<br>10<br>10</td>
-      <td class="total-cell">0.00<br>31<br>45<br>39<br>39</td>
+      <td>7.25|7.25<br>x<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>-<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x<br>x</td>
+      <td class="total-cell">151.50<br>7<br>10<br>10<br>10</td>
+      <td>7.00|7.00<br>x<br>x<br>-<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>-<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>-<br>x</td>
+      <td>7.25|7.25<br>x<br>-<br>-<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>-<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>-<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>-<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>-<br>x</td>
+      <td>7.00|7.00<br>-<br>x<br>-<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>-<br>x</td>
+      <td class="total-cell">151.50<br>7<br>9<br>0<br>9</td>
+      <td>7.25|7.25<br>x<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>-</td>
+      <td>7.50|7.50<br>-<br>x<br>x<br>-</td>
+      <td>8.25|8.25<br>-<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>-<br>x<br>x<br>-</td>
+      <td>7.25|7.25<br>x<br>x<br>x<br>-</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>-<br>-</td>
+      <td>7.50|7.50<br>x<br>x<br>x<br>-</td>
+      <td>7.25|7.25<br>-<br>x<br>x<br>-</td>
+      <td class="total-cell">153.50<br>6<br>10<br>9<br>0</td>
+      <td>7.25|7.25<br>x<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>-<br>x<br>x</td>
+      <td>7.25|7.25<br>-<br>-<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>-<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>-<br>x<br>x</td>
+      <td>7.25|7.25<br>-<br>x<br>x<br>x</td>
+      <td class="total-cell">152.00<br>6<br>6<br>10<br>10</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>-<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x<br>x</td>
+      <td>7.00|7.00<br>-<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>x<br>x</td>
+      <td class="total-cell">150.00<br>5<br>10<br>10<br>10</td>
+      <td class="total-cell">758.50<br>31<br>45<br>39<br>39</td>
     </tr>
     <tr>
       <td>11.</td>
       <td class="left"><span class="participant">Rares Banu / Catinca Banu</span><span class="affiliation">Austria</span></td>
       <td>611</td>
       <td>5<br>4<br>3<br>2</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td class="total-cell">0.00<br>4<br>10<br>10</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>x<br>-<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td class="total-cell">0.00<br>6<br>9<br>0</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>6<br>10<br>10</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>6<br>10<br>9</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>-<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x</td>
-      <td class="total-cell">0.00<br>6<br>9<br>9</td>
-      <td class="total-cell">0.00<br>28<br>48<br>38</td>
+      <td>7.25|7.25<br>-<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>8.25|8.25<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>-<br>x<br>x</td>
+      <td class="total-cell">151.50<br>4<br>10<br>10</td>
+      <td>7.00|7.00<br>-<br>x<br>-</td>
+      <td>7.75|7.75<br>-<br>x<br>-</td>
+      <td>7.75|7.75<br>x<br>x<br>-</td>
+      <td>7.25|7.25<br>x<br>x<br>-</td>
+      <td>7.50|7.50<br>-<br>x<br>-</td>
+      <td>7.25|7.25<br>x<br>-<br>-</td>
+      <td>7.75|7.75<br>x<br>x<br>-</td>
+      <td>7.75|7.75<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>-</td>
+      <td>7.50|7.50<br>-<br>x<br>-</td>
+      <td class="total-cell">151.00<br>6<br>9<br>0</td>
+      <td>7.00|7.00<br>-<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x</td>
+      <td>7.00|7.00<br>x<br>x<br>x</td>
+      <td class="total-cell">150.50<br>6<br>10<br>10</td>
+      <td>7.00|7.00<br>-<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>-</td>
+      <td>7.50|7.50<br>-<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>7.00|7.00<br>x<br>x<br>x</td>
+      <td class="total-cell">150.50<br>6<br>10<br>9</td>
+      <td>7.00|7.00<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>-<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>-</td>
+      <td>7.50|7.50<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>-<br>x<br>x</td>
+      <td>7.25|7.25<br>-<br>x<br>x</td>
+      <td class="total-cell">150.00<br>6<br>9<br>9</td>
+      <td class="total-cell">753.50<br>28<br>48<br>38</td>
     </tr>
     <tr>
       <td>12.</td>
       <td class="left"><span class="participant">Florian Baudoux / Natalia Sadowska</span><span class="affiliation">France</span></td>
       <td>495</td>
       <td>5<br>4<br>3<br>2<br>1</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>7<br>10<br>10<br>10</td>
-      <td>0.00<br>-<br>x<br>-<br>x</td>
-      <td>0.00<br>-<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>-<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td class="total-cell">0.00<br>7<br>10<br>0<br>10</td>
-      <td>0.00<br>-<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>-<br>-</td>
-      <td>0.00<br>-<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>-<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>-<br>-</td>
-      <td class="total-cell">0.00<br>5<br>9<br>8<br>0</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>5<br>10<br>9<br>10</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>-<br>x<br>x</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>-<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>-</td>
-      <td>0.00<br>-<br>x<br>x<br>x</td>
-      <td>0.00<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">0.00<br>6<br>9<br>9<br>9</td>
-      <td class="total-cell">0.00<br>30<br>48<br>36<br>39</td>
+      <td>7.00|7.00<br>-<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x<br>x</td>
+      <td>7.00|7.00<br>-<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x<br>x</td>
+      <td class="total-cell">149.00<br>7<br>10<br>10<br>10</td>
+      <td>7.00|7.00<br>-<br>x<br>-<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>-<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>-<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>-<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>-<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>-<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>-<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>-<br>x</td>
+      <td>7.00|7.00<br>-<br>x<br>-<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>-<br>x</td>
+      <td class="total-cell">151.00<br>7<br>10<br>0<br>10</td>
+      <td>7.00|7.00<br>-<br>x<br>x<br>-</td>
+      <td>7.50|7.50<br>-<br>x<br>-<br>-</td>
+      <td>7.75|7.75<br>-<br>x<br>x<br>-</td>
+      <td>7.25|7.25<br>x<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>-</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>-</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>-</td>
+      <td>7.00|7.00<br>-<br>-<br>x<br>-</td>
+      <td>7.25|7.25<br>-<br>x<br>-<br>-</td>
+      <td class="total-cell">151.00<br>5<br>9<br>8<br>0</td>
+      <td>7.00|7.00<br>-<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>-<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>-<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>-<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
+      <td>7.00|7.00<br>-<br>x<br>x<br>x</td>
+      <td>7.25|7.25<br>x<br>x<br>x<br>x</td>
+      <td class="total-cell">149.50<br>5<br>10<br>9<br>10</td>
+      <td>7.00|7.00<br>-<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>-<br>x<br>x<br>x</td>
+      <td>7.75|7.75<br>x<br>-<br>x<br>x</td>
+      <td>7.25|7.25<br>-<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>-<br>x</td>
+      <td>8.00|8.00<br>x<br>x<br>x<br>-</td>
+      <td>7.25|7.25<br>-<br>x<br>x<br>x</td>
+      <td>7.50|7.50<br>x<br>x<br>x<br>x</td>
+      <td class="total-cell">152.50<br>6<br>9<br>9<br>9</td>
+      <td class="total-cell">753.00<br>30<br>48<br>36<br>39</td>
     </tr>
     <tr>
       <td>13.</td>

--- a/tests/75-0607_wdsfworldopenstdadult/tabges.json
+++ b/tests/75-0607_wdsfworldopenstdadult/tabges.json
@@ -13909,35 +13909,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "427": {
@@ -13946,35 +13946,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "462": {
@@ -13983,35 +13983,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Tango": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Quickstep": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "465": {
@@ -14020,35 +14020,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "Tango": {
               "technical_quality": 7.0,
               "movement_to_music": 0.0,
               "partnering_skills": 7.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.0
             },
             "VienneseWaltz": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "SlowFoxtrot": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "Quickstep": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "495": {
@@ -14057,35 +14057,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.0
             },
             "Tango": {
               "technical_quality": 7.0,
               "movement_to_music": 0.0,
               "partnering_skills": 7.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.0
             },
             "VienneseWaltz": {
               "technical_quality": 7.0,
               "movement_to_music": 0.0,
               "partnering_skills": 7.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.0
             },
             "SlowFoxtrot": {
               "technical_quality": 7.0,
               "movement_to_music": 0.0,
               "partnering_skills": 7.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.0
             },
             "Quickstep": {
               "technical_quality": 7.0,
               "movement_to_music": 0.0,
               "partnering_skills": 7.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.0
             }
           },
           "575": {
@@ -14094,35 +14094,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Tango": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "VienneseWaltz": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "SlowFoxtrot": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Quickstep": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "611": {
@@ -14131,35 +14131,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "Tango": {
               "technical_quality": 7.0,
               "movement_to_music": 0.0,
               "partnering_skills": 7.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.0
             },
             "VienneseWaltz": {
               "technical_quality": 7.0,
               "movement_to_music": 0.0,
               "partnering_skills": 7.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.0
             },
             "SlowFoxtrot": {
               "technical_quality": 7.0,
               "movement_to_music": 0.0,
               "partnering_skills": 7.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.0
             },
             "Quickstep": {
               "technical_quality": 7.0,
               "movement_to_music": 0.0,
               "partnering_skills": 7.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.0
             }
           },
           "645": {
@@ -14168,35 +14168,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "708": {
@@ -14205,35 +14205,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "716": {
@@ -14242,35 +14242,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "876": {
@@ -14279,35 +14279,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.0
             },
             "Tango": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "VienneseWaltz": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "SlowFoxtrot": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "Quickstep": {
               "technical_quality": 7.0,
               "movement_to_music": 0.0,
               "partnering_skills": 7.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.0
             }
           },
           "958": {
@@ -14316,35 +14316,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "Tango": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "VienneseWaltz": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "SlowFoxtrot": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "Quickstep": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             }
           }
         },
@@ -14355,35 +14355,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Tango": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "427": {
@@ -14392,35 +14392,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "462": {
@@ -14429,35 +14429,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "465": {
@@ -14466,35 +14466,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Tango": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "495": {
@@ -14503,35 +14503,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "Tango": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "VienneseWaltz": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "SlowFoxtrot": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "Quickstep": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "575": {
@@ -14540,35 +14540,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Tango": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "VienneseWaltz": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "SlowFoxtrot": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Quickstep": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "611": {
@@ -14577,35 +14577,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "Tango": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "VienneseWaltz": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "SlowFoxtrot": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Quickstep": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "645": {
@@ -14614,35 +14614,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "708": {
@@ -14651,35 +14651,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "716": {
@@ -14688,35 +14688,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "876": {
@@ -14725,35 +14725,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Tango": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "VienneseWaltz": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "SlowFoxtrot": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Quickstep": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "958": {
@@ -14762,35 +14762,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Tango": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           }
         },
@@ -14801,35 +14801,35 @@
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "427": {
@@ -14838,35 +14838,35 @@
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "462": {
@@ -14875,35 +14875,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "465": {
@@ -14912,35 +14912,35 @@
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             }
           },
           "495": {
@@ -14949,35 +14949,35 @@
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "575": {
@@ -14986,35 +14986,35 @@
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "611": {
@@ -15023,35 +15023,35 @@
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "645": {
@@ -15060,35 +15060,35 @@
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "708": {
@@ -15097,35 +15097,35 @@
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "716": {
@@ -15134,35 +15134,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "876": {
@@ -15171,35 +15171,35 @@
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "958": {
@@ -15208,35 +15208,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           }
         },
@@ -15247,35 +15247,35 @@
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "427": {
@@ -15284,35 +15284,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "462": {
@@ -15321,35 +15321,35 @@
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "465": {
@@ -15358,35 +15358,35 @@
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             }
           },
           "495": {
@@ -15395,35 +15395,35 @@
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             }
           },
           "575": {
@@ -15432,35 +15432,35 @@
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "611": {
@@ -15469,35 +15469,35 @@
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             }
           },
           "645": {
@@ -15506,35 +15506,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "708": {
@@ -15543,35 +15543,35 @@
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "716": {
@@ -15580,35 +15580,35 @@
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "876": {
@@ -15617,35 +15617,35 @@
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             }
           },
           "958": {
@@ -15654,35 +15654,35 @@
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             }
           }
         },
@@ -15693,35 +15693,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "427": {
@@ -15730,35 +15730,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "462": {
@@ -15767,35 +15767,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "465": {
@@ -15804,35 +15804,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "495": {
@@ -15841,35 +15841,35 @@
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "575": {
@@ -15878,35 +15878,35 @@
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "611": {
@@ -15915,35 +15915,35 @@
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             }
           },
           "645": {
@@ -15952,35 +15952,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "708": {
@@ -15989,35 +15989,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "716": {
@@ -16026,35 +16026,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "876": {
@@ -16063,35 +16063,35 @@
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "958": {
@@ -16100,35 +16100,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           }
         },
@@ -16139,35 +16139,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "427": {
@@ -16176,35 +16176,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "462": {
@@ -16213,35 +16213,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Tango": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "465": {
@@ -16250,35 +16250,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "Tango": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "VienneseWaltz": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "SlowFoxtrot": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "Quickstep": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             }
           },
           "495": {
@@ -16287,35 +16287,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Tango": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "575": {
@@ -16324,35 +16324,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Tango": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "VienneseWaltz": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "SlowFoxtrot": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Quickstep": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "611": {
@@ -16361,35 +16361,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "Tango": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "VienneseWaltz": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "SlowFoxtrot": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "Quickstep": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             }
           },
           "645": {
@@ -16398,35 +16398,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "708": {
@@ -16435,35 +16435,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Tango": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "VienneseWaltz": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "SlowFoxtrot": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Quickstep": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "716": {
@@ -16472,35 +16472,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "876": {
@@ -16509,35 +16509,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "Tango": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "VienneseWaltz": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "SlowFoxtrot": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "Quickstep": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             }
           },
           "958": {
@@ -16546,35 +16546,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Tango": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "SlowFoxtrot": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Quickstep": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           }
         },
@@ -16585,35 +16585,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Tango": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "427": {
@@ -16622,35 +16622,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "462": {
@@ -16659,35 +16659,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Tango": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "465": {
@@ -16696,35 +16696,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Tango": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "SlowFoxtrot": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Quickstep": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             }
           },
           "495": {
@@ -16733,35 +16733,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Tango": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "VienneseWaltz": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "SlowFoxtrot": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Quickstep": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             }
           },
           "575": {
@@ -16770,35 +16770,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Tango": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "VienneseWaltz": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "SlowFoxtrot": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Quickstep": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "611": {
@@ -16807,35 +16807,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Tango": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "VienneseWaltz": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "SlowFoxtrot": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Quickstep": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "645": {
@@ -16844,35 +16844,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Tango": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "VienneseWaltz": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "SlowFoxtrot": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Quickstep": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "708": {
@@ -16881,35 +16881,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Tango": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "716": {
@@ -16918,35 +16918,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Tango": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "876": {
@@ -16955,35 +16955,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "Tango": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "SlowFoxtrot": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Quickstep": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "958": {
@@ -16992,35 +16992,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "Tango": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "VienneseWaltz": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "SlowFoxtrot": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "Quickstep": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             }
           }
         },
@@ -17031,35 +17031,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "427": {
@@ -17068,35 +17068,35 @@
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "462": {
@@ -17105,35 +17105,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "465": {
@@ -17142,35 +17142,35 @@
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "495": {
@@ -17179,35 +17179,35 @@
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "575": {
@@ -17216,35 +17216,35 @@
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "611": {
@@ -17253,35 +17253,35 @@
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             }
           },
           "645": {
@@ -17290,35 +17290,35 @@
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "708": {
@@ -17327,35 +17327,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "716": {
@@ -17364,35 +17364,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "876": {
@@ -17401,35 +17401,35 @@
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "958": {
@@ -17438,35 +17438,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             }
           }
         },
@@ -17477,35 +17477,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "427": {
@@ -17514,35 +17514,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "462": {
@@ -17551,35 +17551,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "465": {
@@ -17588,35 +17588,35 @@
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.0,
               "partnering_skills": 0.0,
               "choreography": 7.0,
-              "total": 0.0
+              "total": 14.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.0,
               "partnering_skills": 0.0,
               "choreography": 7.0,
-              "total": 0.0
+              "total": 14.0
             }
           },
           "495": {
@@ -17625,35 +17625,35 @@
               "movement_to_music": 7.0,
               "partnering_skills": 0.0,
               "choreography": 7.0,
-              "total": 0.0
+              "total": 14.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.0,
               "partnering_skills": 0.0,
               "choreography": 7.0,
-              "total": 0.0
+              "total": 14.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.0,
               "partnering_skills": 0.0,
               "choreography": 7.0,
-              "total": 0.0
+              "total": 14.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 7.0,
               "partnering_skills": 0.0,
               "choreography": 7.0,
-              "total": 0.0
+              "total": 14.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             }
           },
           "575": {
@@ -17662,35 +17662,35 @@
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.5
             }
           },
           "611": {
@@ -17699,35 +17699,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "645": {
@@ -17736,35 +17736,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "708": {
@@ -17773,35 +17773,35 @@
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.0,
               "partnering_skills": 0.0,
               "choreography": 7.0,
-              "total": 0.0
+              "total": 14.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 6.25,
               "partnering_skills": 0.0,
               "choreography": 6.25,
-              "total": 0.0
+              "total": 12.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             }
           },
           "716": {
@@ -17810,35 +17810,35 @@
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             }
           },
           "876": {
@@ -17847,35 +17847,35 @@
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 7.75,
-              "total": 0.0
+              "total": 15.5
             }
           },
           "958": {
@@ -17884,35 +17884,35 @@
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 7.25,
               "partnering_skills": 0.0,
               "choreography": 7.25,
-              "total": 0.0
+              "total": 14.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 7.5,
               "partnering_skills": 0.0,
               "choreography": 7.5,
-              "total": 0.0
+              "total": 15.0
             }
           }
         },
@@ -17923,35 +17923,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "427": {
@@ -17960,35 +17960,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "462": {
@@ -17997,35 +17997,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "465": {
@@ -18034,35 +18034,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "Tango": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "VienneseWaltz": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "SlowFoxtrot": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "Quickstep": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             }
           },
           "495": {
@@ -18071,35 +18071,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "Tango": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "VienneseWaltz": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "SlowFoxtrot": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "Quickstep": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             }
           },
           "575": {
@@ -18108,35 +18108,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Tango": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "VienneseWaltz": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "SlowFoxtrot": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Quickstep": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "611": {
@@ -18145,35 +18145,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "Tango": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "VienneseWaltz": {
               "technical_quality": 7.0,
               "movement_to_music": 0.0,
               "partnering_skills": 7.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.0
             },
             "SlowFoxtrot": {
               "technical_quality": 7.0,
               "movement_to_music": 0.0,
               "partnering_skills": 7.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.0
             },
             "Quickstep": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             }
           },
           "645": {
@@ -18182,35 +18182,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "708": {
@@ -18219,35 +18219,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "716": {
@@ -18256,35 +18256,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "876": {
@@ -18293,35 +18293,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             },
             "Tango": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "VienneseWaltz": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "SlowFoxtrot": {
               "technical_quality": 7.25,
               "movement_to_music": 0.0,
               "partnering_skills": 7.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 14.5
             },
             "Quickstep": {
               "technical_quality": 7.5,
               "movement_to_music": 0.0,
               "partnering_skills": 7.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.0
             }
           },
           "958": {
@@ -18330,35 +18330,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           }
         }
@@ -18383,35 +18383,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.25
             },
             "Tango": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.25
             },
             "VienneseWaltz": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "427": {
@@ -18420,35 +18420,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.25
             },
             "Tango": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "462": {
@@ -18457,35 +18457,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Tango": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "575": {
@@ -18494,35 +18494,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.25
             },
             "Tango": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "VienneseWaltz": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "SlowFoxtrot": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Quickstep": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "645": {
@@ -18531,35 +18531,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Quickstep": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "716": {
@@ -18568,35 +18568,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           }
         },
@@ -18607,35 +18607,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.25
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "427": {
@@ -18644,35 +18644,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.25
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "462": {
@@ -18681,35 +18681,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "575": {
@@ -18718,35 +18718,35 @@
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.75
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "645": {
@@ -18755,35 +18755,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 17.75
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "716": {
@@ -18792,35 +18792,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.25
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           }
         },
@@ -18831,35 +18831,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.25
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 7.75,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 15.75
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "427": {
@@ -18868,35 +18868,35 @@
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.75
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "462": {
@@ -18905,35 +18905,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 16.75
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "575": {
@@ -18942,35 +18942,35 @@
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.75,
-              "total": 0.0
+              "total": 19.25
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "645": {
@@ -18979,35 +18979,35 @@
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.25
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "716": {
@@ -19016,35 +19016,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           }
         },
@@ -19055,35 +19055,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "427": {
@@ -19092,35 +19092,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "462": {
@@ -19129,35 +19129,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "575": {
@@ -19166,35 +19166,35 @@
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "645": {
@@ -19203,35 +19203,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "716": {
@@ -19240,35 +19240,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.25
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           }
         },
@@ -19279,35 +19279,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "427": {
@@ -19316,35 +19316,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "462": {
@@ -19353,35 +19353,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.75
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "575": {
@@ -19390,35 +19390,35 @@
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.25
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.25
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 9.25,
               "partnering_skills": 0.0,
               "choreography": 9.25,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "645": {
@@ -19427,35 +19427,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "716": {
@@ -19464,35 +19464,35 @@
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.25
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           }
         },
@@ -19503,35 +19503,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.75
             },
             "Tango": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "427": {
@@ -19540,35 +19540,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "462": {
@@ -19577,35 +19577,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.75
             },
             "VienneseWaltz": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "575": {
@@ -19614,35 +19614,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Tango": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "VienneseWaltz": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "SlowFoxtrot": {
               "technical_quality": 9.75,
               "movement_to_music": 0.0,
               "partnering_skills": 9.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.5
             },
             "Quickstep": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "645": {
@@ -19651,35 +19651,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.75
             },
             "VienneseWaltz": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Quickstep": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "716": {
@@ -19688,35 +19688,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.25
             },
             "Tango": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           }
         },
@@ -19727,35 +19727,35 @@
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "427": {
@@ -19764,35 +19764,35 @@
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 16.75
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "462": {
@@ -19801,35 +19801,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 16.75
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.5,
               "partnering_skills": 0.0,
               "choreography": 8.5,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "575": {
@@ -19838,35 +19838,35 @@
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.25
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 9.75,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.25
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 9.5,
               "partnering_skills": 0.0,
               "choreography": 9.5,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "645": {
@@ -19875,35 +19875,35 @@
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.75
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 9.0,
               "partnering_skills": 0.0,
               "choreography": 9.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.75,
               "partnering_skills": 0.0,
               "choreography": 8.75,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "716": {
@@ -19912,35 +19912,35 @@
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             },
             "SlowFoxtrot": {
               "technical_quality": 0.0,
               "movement_to_music": 8.25,
               "partnering_skills": 0.0,
               "choreography": 8.25,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 0.0,
               "movement_to_music": 8.0,
               "partnering_skills": 0.0,
               "choreography": 8.0,
-              "total": 0.0
+              "total": 16.0
             }
           }
         },
@@ -19951,35 +19951,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.75
             },
             "Tango": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "427": {
@@ -19988,35 +19988,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Tango": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "VienneseWaltz": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "SlowFoxtrot": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Quickstep": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "462": {
@@ -20025,35 +20025,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.25
             },
             "Tango": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "575": {
@@ -20062,35 +20062,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Tango": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "VienneseWaltz": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "SlowFoxtrot": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "Quickstep": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             }
           },
           "645": {
@@ -20099,35 +20099,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Tango": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "VienneseWaltz": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "SlowFoxtrot": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Quickstep": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             }
           },
           "716": {
@@ -20136,35 +20136,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "Quickstep": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           }
         },
@@ -20175,35 +20175,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "427": {
@@ -20212,35 +20212,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.25
             },
             "Tango": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.25
             },
             "VienneseWaltz": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "462": {
@@ -20249,35 +20249,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "575": {
@@ -20286,35 +20286,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.5
             },
             "Tango": {
               "technical_quality": 9.75,
               "movement_to_music": 0.0,
               "partnering_skills": 9.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.5
             },
             "VienneseWaltz": {
               "technical_quality": 9.5,
               "movement_to_music": 0.0,
               "partnering_skills": 9.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.0
             },
             "SlowFoxtrot": {
               "technical_quality": 9.75,
               "movement_to_music": 0.0,
               "partnering_skills": 9.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.5
             },
             "Quickstep": {
               "technical_quality": 9.75,
               "movement_to_music": 0.0,
               "partnering_skills": 9.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 19.5
             }
           },
           "645": {
@@ -20323,35 +20323,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.25
             },
             "VienneseWaltz": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           },
           "716": {
@@ -20360,35 +20360,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Tango": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.25
             },
             "VienneseWaltz": {
               "technical_quality": 7.75,
               "movement_to_music": 0.0,
               "partnering_skills": 7.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 15.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           }
         },
@@ -20399,35 +20399,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.75
             },
             "Tango": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.75
             },
             "VienneseWaltz": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Quickstep": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             }
           },
           "427": {
@@ -20436,35 +20436,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.25
             },
             "Tango": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.25
             },
             "VienneseWaltz": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "462": {
@@ -20473,35 +20473,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "Tango": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 8.25,
               "movement_to_music": 0.0,
               "partnering_skills": 8.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             },
             "Quickstep": {
               "technical_quality": 8.0,
               "movement_to_music": 0.0,
               "partnering_skills": 8.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 16.0
             }
           },
           "575": {
@@ -20510,35 +20510,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Tango": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "VienneseWaltz": {
               "technical_quality": 9.0,
               "movement_to_music": 0.0,
               "partnering_skills": 9.0,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.0
             },
             "SlowFoxtrot": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             },
             "Quickstep": {
               "technical_quality": 9.25,
               "movement_to_music": 0.0,
               "partnering_skills": 9.25,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 18.5
             }
           },
           "645": {
@@ -20547,35 +20547,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Tango": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "VienneseWaltz": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "SlowFoxtrot": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             },
             "Quickstep": {
               "technical_quality": 8.75,
               "movement_to_music": 0.0,
               "partnering_skills": 8.75,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.5
             }
           },
           "716": {
@@ -20584,35 +20584,35 @@
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Tango": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "VienneseWaltz": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "SlowFoxtrot": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             },
             "Quickstep": {
               "technical_quality": 8.5,
               "movement_to_music": 0.0,
               "partnering_skills": 8.5,
               "choreography": 0.0,
-              "total": 0.0
+              "total": 17.0
             }
           }
         }


### PR DESCRIPTION
This PR fixes the issue where WDSF final rounds were showing 0.0 for results.

Root cause analysis:
1. WDSF results often split a single judge's scores across multiple columns (e.g., Column 1: TQ|PS, Column 2: MM|CP). The previous merging logic was overwriting valid data from one column with empty values from the other.
2. Preliminary WDSF rounds use the Skating system (crosses), but were sometimes misidentified as WDSF absolute scoring rounds, leading to data loss because crosses ('x') weren't being captured by decimal regexes.

Fixes:
- Updated merging logic to be component-aware: it now aggregates individual categories (TQ, MM, PS, CP) and recalculates the total.
- Implemented additive merging for crosses in preliminary rounds to ensure data from split columns is preserved.
- Enhanced round classification to only use WDSF absolute scoring model if decimal scores are actually present in the table.
- Updated the HTML generator to show granular component scores in a compact, vertically-aligned format.

The fix has been verified against all 15 integration tests, ensuring zero regression for national (DTV) competitions while restoring full fidelity to WDSF results.

---
*PR created automatically by Jules for task [17564985458973273043](https://jules.google.com/task/17564985458973273043) started by @phyk*