### PR TITLE
Correct WDSF summarization logic to use category averages

### DIFF
--- a/src/models/skating.rs
+++ b/src/models/skating.rs
@@ -316,8 +316,62 @@ pub fn verify_wdsf_score(score: &WDSFScore) -> bool {
         + score.partnering_skills
         + score.choreography;
 
-    let mean = calculated_sum / 4.0;
-    (mean - score.total).abs() < 0.011 || (calculated_sum - score.total).abs() < 0.011
+    // Check if total is the sum of components
+    (calculated_sum - score.total).abs() < 0.011
+}
+
+/// Calculates the WDSF dance score as the sum of category averages.
+pub fn calculate_wdsf_dance_score(judge_scores: &BTreeMap<String, WDSFScore>) -> f64 {
+    let mut tq_sum = 0.0;
+    let mut tq_count = 0;
+    let mut mm_sum = 0.0;
+    let mut mm_count = 0;
+    let mut ps_sum = 0.0;
+    let mut ps_count = 0;
+    let mut cp_sum = 0.0;
+    let mut cp_count = 0;
+
+    for score in judge_scores.values() {
+        if score.technical_quality > 0.0 {
+            tq_sum += score.technical_quality;
+            tq_count += 1;
+        }
+        if score.movement_to_music > 0.0 {
+            mm_sum += score.movement_to_music;
+            mm_count += 1;
+        }
+        if score.partnering_skills > 0.0 {
+            ps_sum += score.partnering_skills;
+            ps_count += 1;
+        }
+        if score.choreography > 0.0 {
+            cp_sum += score.choreography;
+            cp_count += 1;
+        }
+    }
+
+    let tq_avg = if tq_count > 0 {
+        tq_sum / tq_count as f64
+    } else {
+        0.0
+    };
+    let mm_avg = if mm_count > 0 {
+        mm_sum / mm_count as f64
+    } else {
+        0.0
+    };
+    let ps_avg = if ps_count > 0 {
+        ps_sum / ps_count as f64
+    } else {
+        0.0
+    };
+    let cp_avg = if cp_count > 0 {
+        cp_sum / cp_count as f64
+    } else {
+        0.0
+    };
+
+    tq_avg + mm_avg + ps_avg + cp_avg
 }
 
 #[cfg(test)]
@@ -443,7 +497,7 @@ mod tests {
             movement_to_music: 8.0,
             partnering_skills: 8.5,
             choreography: 9.0,
-            total: 8.5,
+            total: 34.0,
         };
         assert!(verify_wdsf_score(&score));
         let bad_score = WDSFScore {
@@ -454,5 +508,38 @@ mod tests {
             total: 9.5,
         };
         assert!(!verify_wdsf_score(&bad_score));
+    }
+
+    #[test]
+    fn test_calculate_wdsf_dance_score() {
+        let mut judge_scores = BTreeMap::new();
+        judge_scores.insert(
+            "A".to_string(),
+            WDSFScore {
+                technical_quality: 8.0,
+                movement_to_music: 7.0,
+                partnering_skills: 0.0,
+                choreography: 9.0,
+                total: 24.0,
+            },
+        );
+        judge_scores.insert(
+            "B".to_string(),
+            WDSFScore {
+                technical_quality: 9.0,
+                movement_to_music: 0.0,
+                partnering_skills: 8.0,
+                choreography: 8.0,
+                total: 25.0,
+            },
+        );
+
+        // TQ: (8+9)/2 = 8.5
+        // MM: 7/1 = 7.0
+        // PS: 8/1 = 8.0
+        // CP: (9+8)/2 = 8.5
+        // Total: 8.5 + 7.0 + 8.0 + 8.5 = 32.0
+        let score = calculate_wdsf_dance_score(&judge_scores);
+        assert!((score - 32.0).abs() < 0.001);
     }
 }

--- a/src/models/validation.rs
+++ b/src/models/validation.rs
@@ -167,6 +167,7 @@ pub fn validate_competition_fidelity(comp: &Competition) -> bool {
             RoundData::WDSF { .. } => {
                 // WDSF rank calculation is complex (averages, drop high/low),
                 // so we rely on verify_round_math for component validity.
+                // We could also verify that calculated sums match if they were provided in the source.
             }
             _ => {}
         }

--- a/src/sources/html_gen.rs
+++ b/src/sources/html_gen.rs
@@ -203,20 +203,20 @@ pub fn competition_to_html(comp: &Competition) -> String {
                         }
                     }
                     RoundData::WDSF { wdsf_scores } => {
-                        let mut total_score = 0.0;
-                        let mut count = 0;
+                        let mut judge_scores = BTreeMap::new();
                         for judge in &comp.officials.judges {
                             if let Some(jm) = wdsf_scores.get(&judge.code) {
                                 if let Some(pm) = jm.get(&p.bib_number) {
                                     if let Some(score) = pm.get(&dance) {
-                                        total_score += score.total;
-                                        count += 1;
+                                        judge_scores.insert(judge.code.clone(), score.clone());
                                     }
                                 }
                             }
                         }
-                        if count > 0 {
-                            write!(sum_cell, "{:.2}", total_score).unwrap();
+                        if !judge_scores.is_empty() {
+                            let dance_score =
+                                crate::models::skating::calculate_wdsf_dance_score(&judge_scores);
+                            write!(sum_cell, "{:.2}", dance_score).unwrap();
                         }
                     }
                 }
@@ -280,14 +280,21 @@ pub fn competition_to_html(comp: &Competition) -> String {
                     }
                 }
                 RoundData::WDSF { wdsf_scores } => {
-                    for judge in &comp.officials.judges {
-                        if let Some(jm) = wdsf_scores.get(&judge.code) {
-                            if let Some(pm) = jm.get(&p.bib_number) {
-                                for score in pm.values() {
-                                    round_total += score.total;
-                                    has_data = true;
+                    for &dance in &comp.dances {
+                        let mut judge_scores = BTreeMap::new();
+                        for judge in &comp.officials.judges {
+                            if let Some(jm) = wdsf_scores.get(&judge.code) {
+                                if let Some(pm) = jm.get(&p.bib_number) {
+                                    if let Some(score) = pm.get(&dance) {
+                                        judge_scores.insert(judge.code.clone(), score.clone());
+                                    }
                                 }
                             }
+                        }
+                        if !judge_scores.is_empty() {
+                            round_total +=
+                                crate::models::skating::calculate_wdsf_dance_score(&judge_scores);
+                            has_data = true;
                         }
                     }
                     if has_data {

--- a/tests/44-0507_wdsfworldopenlatadult/reconstructed_ergwert.html
+++ b/tests/44-0507_wdsfworldopenlatadult/reconstructed_ergwert.html
@@ -107,7 +107,7 @@
       <td>9.50|9.75<br>9.75|9.75<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.25|9.25<br>x<br>x<br>x</td>
-      <td class="total-cell">191.50<br>191.00<br>9<br>10<br>10</td>
+      <td class="total-cell">38.30<br>38.20<br>9<br>10<br>10</td>
       <td>9.75|9.75<br>9.50|9.50<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
@@ -118,7 +118,7 @@
       <td>9.75|9.75<br>9.75|9.75<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.25|9.25<br>x<br>x<br>x</td>
-      <td class="total-cell">191.50<br>190.50<br>10<br>10<br>10</td>
+      <td class="total-cell">38.30<br>38.10<br>10<br>10<br>10</td>
       <td>9.75|9.75<br>9.75|9.75<br>x<br>x<br>-</td>
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>-</td>
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>-</td>
@@ -129,7 +129,7 @@
       <td>9.50|9.75<br>9.50|9.50<br>x<br>x<br>-</td>
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>-</td>
       <td>9.50|9.50<br>9.25|9.25<br>x<br>x<br>-</td>
-      <td class="total-cell">191.50<br>191.00<br>10<br>10<br>0</td>
+      <td class="total-cell">38.30<br>38.20<br>10<br>10<br>0</td>
       <td>9.75|9.75<br>9.75|9.75<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
       <td>9.75|9.75<br>9.50|9.50<br>x<br>x<br>x</td>
@@ -140,7 +140,7 @@
       <td>9.75|9.75<br>8.50|8.50<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
-      <td class="total-cell">192.00<br>188.50<br>10<br>9<br>10</td>
+      <td class="total-cell">38.40<br>37.70<br>10<br>9<br>10</td>
       <td>9.75|9.75<br>9.75|9.75<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.75|9.75<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.75|9.75<br>x<br>x<br>x</td>
@@ -151,8 +151,8 @@
       <td>9.75|9.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.25|9.25<br>x<br>x<br>x</td>
-      <td class="total-cell">191.50<br>189.50<br>10<br>10<br>10</td>
-      <td class="total-cell">958.00<br>950.50<br>49<br>49<br>40</td>
+      <td class="total-cell">38.30<br>37.90<br>10<br>10<br>10</td>
+      <td class="total-cell">191.60<br>190.10<br>49<br>49<br>40</td>
     </tr>
     <tr>
       <td>2.</td>
@@ -169,7 +169,7 @@
       <td>9.50|9.25<br>9.50|9.50<br>x<br>x<br>x</td>
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
       <td>9.00|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
-      <td class="total-cell">184.75<br>183.00<br>9<br>10<br>10</td>
+      <td class="total-cell">36.95<br>36.60<br>9<br>10<br>10</td>
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
       <td>9.25|9.25<br>8.75|8.75<br>x<br>x<br>x</td>
@@ -180,7 +180,7 @@
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
       <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
-      <td class="total-cell">184.50<br>183.50<br>10<br>10<br>10</td>
+      <td class="total-cell">36.90<br>36.70<br>10<br>10<br>10</td>
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>-</td>
       <td>9.25|9.50<br>9.25|9.25<br>x<br>x<br>-</td>
       <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>-</td>
@@ -191,7 +191,7 @@
       <td>9.50|9.50<br>9.25|9.25<br>x<br>-<br>-</td>
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>-</td>
       <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>-</td>
-      <td class="total-cell">185.50<br>183.50<br>10<br>9<br>0</td>
+      <td class="total-cell">37.10<br>36.70<br>10<br>9<br>0</td>
       <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
       <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
@@ -202,7 +202,7 @@
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.25|9.25<br>x<br>x<br>x</td>
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
-      <td class="total-cell">185.50<br>184.50<br>10<br>10<br>10</td>
+      <td class="total-cell">37.10<br>36.90<br>10<br>10<br>10</td>
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
@@ -213,8 +213,8 @@
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
       <td>9.25|9.25<br>9.00|9.00<br>-<br>-<br>x</td>
-      <td class="total-cell">184.50<br>184.50<br>9<br>9<br>10</td>
-      <td class="total-cell">924.75<br>919.00<br>48<br>48<br>40</td>
+      <td class="total-cell">36.90<br>36.90<br>9<br>9<br>10</td>
+      <td class="total-cell">184.95<br>183.80<br>48<br>48<br>40</td>
     </tr>
     <tr>
       <td>3.</td>
@@ -231,7 +231,7 @@
       <td>9.00|8.00<br>9.00|9.00<br>x<br>x<br>-</td>
       <td>8.75|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.50|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
-      <td class="total-cell">174.50<br>175.00<br>10<br>10<br>9</td>
+      <td class="total-cell">34.90<br>35.00<br>10<br>10<br>9</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>9.00|9.00<br>9.00|9.00<br>-<br>x<br>x</td>
       <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
@@ -242,7 +242,7 @@
       <td>9.25|9.25<br>8.75|8.75<br>x<br>-<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
-      <td class="total-cell">176.50<br>174.50<br>9<br>9<br>10</td>
+      <td class="total-cell">35.30<br>34.90<br>9<br>9<br>10</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
       <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>-</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
@@ -253,7 +253,7 @@
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
       <td>8.75|8.75<br>8.50|8.50<br>x<br>-<br>-</td>
-      <td class="total-cell">175.50<br>175.00<br>10<br>9<br>0</td>
+      <td class="total-cell">35.10<br>35.00<br>10<br>9<br>0</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
@@ -264,7 +264,7 @@
       <td>8.75|8.75<br>9.00|9.00<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>-<br>-<br>-</td>
-      <td class="total-cell">175.50<br>175.50<br>9<br>8<br>9</td>
+      <td class="total-cell">35.10<br>35.10<br>9<br>8<br>9</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>9.00|9.00<br>9.00|9.00<br>-<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
@@ -275,8 +275,8 @@
       <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>9.75|9.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>-<br>x<br>x</td>
-      <td class="total-cell">177.50<br>177.50<br>8<br>10<br>10</td>
-      <td class="total-cell">879.50<br>877.50<br>46<br>46<br>38</td>
+      <td class="total-cell">35.50<br>35.50<br>8<br>10<br>10</td>
+      <td class="total-cell">175.90<br>175.50<br>46<br>46<br>38</td>
     </tr>
     <tr>
       <td>4.</td>
@@ -293,7 +293,7 @@
       <td>8.50|8.25<br>9.00|9.00<br>x<br>-<br>x</td>
       <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
       <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
-      <td class="total-cell">174.50<br>176.00<br>9<br>8<br>10</td>
+      <td class="total-cell">34.90<br>35.20<br>9<br>8<br>10</td>
       <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>9.00|9.00<br>-<br>x<br>x</td>
       <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
@@ -304,7 +304,7 @@
       <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
       <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
       <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
-      <td class="total-cell">174.00<br>174.50<br>9<br>10<br>10</td>
+      <td class="total-cell">34.80<br>34.90<br>9<br>10<br>10</td>
       <td>8.50|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
       <td>8.50|8.75<br>9.00|9.00<br>x<br>-<br>-</td>
       <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>-</td>
@@ -315,7 +315,7 @@
       <td>9.25|9.50<br>9.00|9.00<br>x<br>x<br>-</td>
       <td>9.00|9.25<br>9.00|9.00<br>x<br>x<br>-</td>
       <td>9.00|9.00<br>8.75|8.75<br>x<br>-<br>-</td>
-      <td class="total-cell">176.50<br>176.00<br>9<br>8<br>0</td>
+      <td class="total-cell">35.30<br>35.20<br>9<br>8<br>0</td>
       <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>9.00|9.00<br>9.25|9.25<br>x<br>x<br>x</td>
@@ -326,7 +326,7 @@
       <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>-</td>
       <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
       <td>9.00|9.00<br>9.00|9.00<br>-<br>x<br>x</td>
-      <td class="total-cell">176.00<br>176.00<br>8<br>10<br>9</td>
+      <td class="total-cell">35.20<br>35.20<br>8<br>10<br>9</td>
       <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>9.00|9.00<br>9.25|9.25<br>x<br>x<br>x</td>
@@ -337,8 +337,8 @@
       <td>9.00|9.00<br>8.50|8.50<br>x<br>x<br>x</td>
       <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
       <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
-      <td class="total-cell">175.00<br>175.00<br>9<br>9<br>10</td>
-      <td class="total-cell">876.00<br>877.50<br>44<br>45<br>39</td>
+      <td class="total-cell">35.00<br>35.00<br>9<br>9<br>10</td>
+      <td class="total-cell">175.20<br>175.50<br>44<br>45<br>39</td>
     </tr>
     <tr>
       <td>5.</td>
@@ -355,7 +355,7 @@
       <td>9.00|9.00<br>9.25|9.25<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
-      <td class="total-cell">174.25<br>175.00<br>10<br>10<br>10</td>
+      <td class="total-cell">34.85<br>35.00<br>10<br>10<br>10</td>
       <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
       <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
@@ -366,7 +366,7 @@
       <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
-      <td class="total-cell">174.00<br>175.50<br>10<br>10<br>10</td>
+      <td class="total-cell">34.80<br>35.10<br>10<br>10<br>10</td>
       <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>-</td>
       <td>8.75|8.75<br>8.75|8.75<br>-<br>x<br>-</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
@@ -377,7 +377,7 @@
       <td>9.00|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
       <td>8.75|9.00<br>8.75|8.75<br>x<br>x<br>-</td>
       <td>8.75|9.00<br>8.75|8.75<br>-<br>-<br>-</td>
-      <td class="total-cell">175.50<br>174.50<br>8<br>8<br>0</td>
+      <td class="total-cell">35.10<br>34.90<br>8<br>8<br>0</td>
       <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>9.00|9.00<br>8.75|8.75<br>x<br>-<br>x</td>
       <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
@@ -388,7 +388,7 @@
       <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
-      <td class="total-cell">174.50<br>174.50<br>10<br>9<br>10</td>
+      <td class="total-cell">34.90<br>34.90<br>10<br>9<br>10</td>
       <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
@@ -399,8 +399,8 @@
       <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
       <td>9.00|9.00<br>9.75|9.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
-      <td class="total-cell">175.50<br>176.50<br>10<br>10<br>10</td>
-      <td class="total-cell">873.75<br>876.00<br>48<br>47<br>40</td>
+      <td class="total-cell">35.10<br>35.30<br>10<br>10<br>10</td>
+      <td class="total-cell">174.75<br>175.20<br>48<br>47<br>40</td>
     </tr>
     <tr>
       <td>6.</td>
@@ -417,7 +417,7 @@
       <td>9.00|9.50<br>8.25|8.25<br>x<br>x<br>x</td>
       <td>8.50|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
-      <td class="total-cell">173.25<br>173.00<br>10<br>10<br>10</td>
+      <td class="total-cell">34.65<br>34.60<br>10<br>10<br>10</td>
       <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
@@ -428,7 +428,7 @@
       <td>8.75|8.75<br>8.25|8.25<br>x<br>-<br>x</td>
       <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>-<br>x<br>x</td>
-      <td class="total-cell">171.50<br>173.50<br>9<br>9<br>10</td>
+      <td class="total-cell">34.30<br>34.70<br>9<br>9<br>10</td>
       <td>8.00|8.25<br>8.25|8.25<br>x<br>x<br>-</td>
       <td>8.75|8.50<br>8.50|8.50<br>-<br>x<br>-</td>
       <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>-</td>
@@ -439,7 +439,7 @@
       <td>8.25|9.00<br>8.50|8.50<br>-<br>-<br>-</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
       <td>9.00|8.75<br>8.50|8.50<br>x<br>x<br>-</td>
-      <td class="total-cell">173.50<br>172.50<br>8<br>9<br>0</td>
+      <td class="total-cell">34.70<br>34.50<br>8<br>9<br>0</td>
       <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
@@ -450,7 +450,7 @@
       <td>8.50|8.50<br>8.00|8.00<br>-<br>-<br>x</td>
       <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
-      <td class="total-cell">172.50<br>172.50<br>9<br>9<br>10</td>
+      <td class="total-cell">34.50<br>34.50<br>9<br>9<br>10</td>
       <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>8.75|8.75<br>-<br>x<br>x</td>
       <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
@@ -461,8 +461,8 @@
       <td>8.75|8.75<br>8.25|8.25<br>-<br>x<br>-</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>-<br>x</td>
-      <td class="total-cell">172.50<br>173.50<br>8<br>9<br>9</td>
-      <td class="total-cell">863.25<br>865.00<br>44<br>46<br>39</td>
+      <td class="total-cell">34.50<br>34.70<br>8<br>9<br>9</td>
+      <td class="total-cell">172.65<br>173.00<br>44<br>46<br>39</td>
     </tr>
     <tr>
       <td>7.</td>
@@ -479,7 +479,7 @@
       <td>8.25|8.25<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
-      <td class="total-cell">164.50<br>9<br>10<br>10</td>
+      <td class="total-cell">32.90<br>9<br>10<br>10</td>
       <td>7.75|7.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>-<br>x<br>x</td>
       <td>8.75|8.75<br>x<br>x<br>x</td>
@@ -490,7 +490,7 @@
       <td>8.50|8.50<br>-<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
-      <td class="total-cell">166.50<br>7<br>10<br>10</td>
+      <td class="total-cell">33.30<br>7<br>10<br>10</td>
       <td>7.75|7.75<br>x<br>x<br>-</td>
       <td>8.75|8.75<br>-<br>x<br>-</td>
       <td>8.75|8.75<br>x<br>x<br>-</td>
@@ -501,7 +501,7 @@
       <td>8.00|8.00<br>x<br>x<br>-</td>
       <td>8.50|8.50<br>x<br>x<br>-</td>
       <td>8.50|8.50<br>x<br>x<br>-</td>
-      <td class="total-cell">166.00<br>7<br>10<br>0</td>
+      <td class="total-cell">33.20<br>7<br>10<br>0</td>
       <td>7.75|7.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>-<br>x<br>x</td>
       <td>8.75|8.75<br>x<br>x<br>x</td>
@@ -512,7 +512,7 @@
       <td>8.25|8.25<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>x<br>-<br>x</td>
-      <td class="total-cell">167.00<br>8<br>9<br>10</td>
+      <td class="total-cell">33.40<br>8<br>9<br>10</td>
       <td>7.75|7.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
@@ -523,8 +523,8 @@
       <td>9.00|9.00<br>x<br>-<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>x<br>x<br>x</td>
-      <td class="total-cell">168.50<br>10<br>9<br>10</td>
-      <td class="total-cell">832.50<br>41<br>48<br>40</td>
+      <td class="total-cell">33.70<br>10<br>9<br>10</td>
+      <td class="total-cell">166.50<br>41<br>48<br>40</td>
     </tr>
     <tr>
       <td>8.</td>
@@ -541,7 +541,7 @@
       <td>8.75|8.75<br>-<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
-      <td class="total-cell">162.50<br>7<br>9<br>10</td>
+      <td class="total-cell">32.50<br>7<br>9<br>10</td>
       <td>8.00|8.00<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x</td>
@@ -552,7 +552,7 @@
       <td>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
-      <td class="total-cell">162.50<br>7<br>9<br>10</td>
+      <td class="total-cell">32.50<br>7<br>9<br>10</td>
       <td>8.00|8.00<br>x<br>x<br>-</td>
       <td>8.00|8.00<br>x<br>x<br>-</td>
       <td>8.50|8.50<br>x<br>x<br>-</td>
@@ -563,7 +563,7 @@
       <td>8.50|8.50<br>-<br>-<br>-</td>
       <td>8.50|8.50<br>x<br>x<br>-</td>
       <td>8.50|8.50<br>-<br>-<br>-</td>
-      <td class="total-cell">162.50<br>5<br>7<br>0</td>
+      <td class="total-cell">32.50<br>5<br>7<br>0</td>
       <td>7.75|7.75<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
@@ -574,7 +574,7 @@
       <td>8.25|8.25<br>-<br>x<br>x</td>
       <td>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
-      <td class="total-cell">162.00<br>7<br>9<br>10</td>
+      <td class="total-cell">32.40<br>7<br>9<br>10</td>
       <td>8.00|8.00<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
@@ -585,8 +585,8 @@
       <td>8.75|8.75<br>x<br>-<br>x</td>
       <td>8.25|8.25<br>-<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
-      <td class="total-cell">162.00<br>6<br>8<br>10</td>
-      <td class="total-cell">811.50<br>32<br>42<br>40</td>
+      <td class="total-cell">32.40<br>6<br>8<br>10</td>
+      <td class="total-cell">162.30<br>32<br>42<br>40</td>
     </tr>
     <tr>
       <td>9.</td>
@@ -603,7 +603,7 @@
       <td>9.00|9.00<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x</td>
-      <td class="total-cell">161.00<br>8<br>10<br>10</td>
+      <td class="total-cell">32.20<br>8<br>10<br>10</td>
       <td>8.00|8.00<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>-<br>x<br>x</td>
@@ -614,7 +614,7 @@
       <td>8.25|8.25<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>-<br>x<br>x</td>
-      <td class="total-cell">160.00<br>6<br>9<br>10</td>
+      <td class="total-cell">32.00<br>6<br>9<br>10</td>
       <td>7.75|7.75<br>x<br>x<br>-</td>
       <td>8.25|8.25<br>-<br>x<br>-</td>
       <td>8.00|8.00<br>-<br>x<br>-</td>
@@ -625,7 +625,7 @@
       <td>9.00|9.00<br>x<br>x<br>-</td>
       <td>8.25|8.25<br>x<br>x<br>-</td>
       <td>8.25|8.25<br>x<br>-<br>-</td>
-      <td class="total-cell">162.00<br>7<br>9<br>0</td>
+      <td class="total-cell">32.40<br>7<br>9<br>0</td>
       <td>7.75|7.75<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>-<br>x<br>x</td>
@@ -636,7 +636,7 @@
       <td>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>-</td>
-      <td class="total-cell">163.50<br>7<br>10<br>9</td>
+      <td class="total-cell">32.70<br>7<br>10<br>9</td>
       <td>7.75|7.75<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>x<br>x<br>x</td>
@@ -647,8 +647,8 @@
       <td>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
-      <td class="total-cell">162.50<br>9<br>10<br>10</td>
-      <td class="total-cell">809.00<br>37<br>48<br>39</td>
+      <td class="total-cell">32.50<br>9<br>10<br>10</td>
+      <td class="total-cell">161.80<br>37<br>48<br>39</td>
     </tr>
     <tr>
       <td>10.</td>
@@ -665,7 +665,7 @@
       <td>8.50|8.50<br>-<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>-<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>-<br>x<br>x<br>x</td>
-      <td class="total-cell">158.00<br>4<br>10<br>10<br>10</td>
+      <td class="total-cell">31.60<br>4<br>10<br>10<br>10</td>
       <td>7.00|7.00<br>-<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
       <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
@@ -676,7 +676,7 @@
       <td>8.75|8.75<br>x<br>x<br>x<br>-</td>
       <td>8.00|8.00<br>-<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>-<br>x<br>x</td>
-      <td class="total-cell">159.00<br>6<br>9<br>10<br>9</td>
+      <td class="total-cell">31.80<br>6<br>9<br>10<br>9</td>
       <td>7.00|7.00<br>-<br>x<br>-<br>x</td>
       <td>8.00|8.00<br>x<br>x<br>-<br>x</td>
       <td>8.00|8.00<br>-<br>x<br>-<br>x</td>
@@ -687,7 +687,7 @@
       <td>8.25|8.25<br>-<br>x<br>-<br>x</td>
       <td>8.00|8.00<br>x<br>x<br>-<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>-<br>x</td>
-      <td class="total-cell">158.50<br>6<br>9<br>0<br>9</td>
+      <td class="total-cell">31.70<br>6<br>9<br>0<br>9</td>
       <td>7.25|7.25<br>-<br>x<br>x<br>-</td>
       <td>8.00|8.00<br>x<br>x<br>x<br>-</td>
       <td>8.00|8.00<br>-<br>x<br>x<br>-</td>
@@ -698,7 +698,7 @@
       <td>8.25|8.25<br>x<br>x<br>-<br>-</td>
       <td>8.00|8.00<br>x<br>x<br>x<br>-</td>
       <td>8.25|8.25<br>x<br>x<br>x<br>-</td>
-      <td class="total-cell">159.50<br>6<br>10<br>9<br>0</td>
+      <td class="total-cell">31.90<br>6<br>10<br>9<br>0</td>
       <td>7.50|7.50<br>-<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>-<br>x<br>x<br>x</td>
@@ -709,8 +709,8 @@
       <td>8.50|8.50<br>-<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>-<br>-<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">162.00<br>6<br>9<br>10<br>10</td>
-      <td class="total-cell">797.00<br>28<br>47<br>39<br>38</td>
+      <td class="total-cell">32.40<br>6<br>9<br>10<br>10</td>
+      <td class="total-cell">159.40<br>28<br>47<br>39<br>38</td>
     </tr>
     <tr>
       <td>11.</td>
@@ -727,7 +727,7 @@
       <td>8.25|8.25<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>-<br>x<br>x</td>
-      <td class="total-cell">158.00<br>4<br>10<br>10</td>
+      <td class="total-cell">31.60<br>4<br>10<br>10</td>
       <td>7.00|7.00<br>-<br>x<br>x</td>
       <td>8.00|8.00<br>-<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
@@ -738,7 +738,7 @@
       <td>8.00|8.00<br>-<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>-<br>x<br>x</td>
-      <td class="total-cell">158.50<br>5<br>10<br>10</td>
+      <td class="total-cell">31.70<br>5<br>10<br>10</td>
       <td>7.00|7.00<br>-<br>x<br>-</td>
       <td>8.00|8.00<br>-<br>-<br>-</td>
       <td>8.25|8.25<br>x<br>x<br>-</td>
@@ -749,7 +749,7 @@
       <td>8.00|8.00<br>x<br>x<br>-</td>
       <td>8.00|8.00<br>x<br>x<br>-</td>
       <td>8.25|8.25<br>x<br>x<br>-</td>
-      <td class="total-cell">157.50<br>5<br>9<br>0</td>
+      <td class="total-cell">31.50<br>5<br>9<br>0</td>
       <td>7.00|7.00<br>-<br>x<br>-</td>
       <td>7.75|7.75<br>-<br>x<br>x</td>
       <td>8.00|8.00<br>x<br>x<br>x</td>
@@ -760,7 +760,7 @@
       <td>8.25|8.25<br>x<br>-<br>x</td>
       <td>8.25|8.25<br>-<br>x<br>-</td>
       <td>8.25|8.25<br>x<br>-<br>x</td>
-      <td class="total-cell">158.00<br>5<br>8<br>8</td>
+      <td class="total-cell">31.60<br>5<br>8<br>8</td>
       <td>7.25|7.25<br>-<br>x<br>x</td>
       <td>7.75|7.75<br>-<br>x<br>x</td>
       <td>8.00|8.00<br>x<br>x<br>x</td>
@@ -771,8 +771,8 @@
       <td>8.00|8.00<br>-<br>-<br>-</td>
       <td>8.25|8.25<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x</td>
-      <td class="total-cell">157.00<br>6<br>9<br>9</td>
-      <td class="total-cell">789.00<br>25<br>46<br>37</td>
+      <td class="total-cell">31.40<br>6<br>9<br>9</td>
+      <td class="total-cell">157.80<br>25<br>46<br>37</td>
     </tr>
     <tr>
       <td>12.</td>
@@ -789,7 +789,7 @@
       <td>8.25|8.25<br>x<br>-<br>x</td>
       <td>7.75|7.75<br>-<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x</td>
-      <td class="total-cell">157.50<br>6<br>9<br>10</td>
+      <td class="total-cell">31.50<br>6<br>9<br>10</td>
       <td>7.75|7.75<br>x<br>x<br>x</td>
       <td>7.50|7.50<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>-<br>x<br>x</td>
@@ -800,7 +800,7 @@
       <td>8.25|8.25<br>-<br>-<br>x</td>
       <td>7.75|7.75<br>-<br>x<br>x</td>
       <td>8.00|8.00<br>x<br>-<br>x</td>
-      <td class="total-cell">157.00<br>6<br>7<br>10</td>
+      <td class="total-cell">31.40<br>6<br>7<br>10</td>
       <td>7.75|7.75<br>x<br>x<br>-</td>
       <td>7.50|7.50<br>x<br>x<br>-</td>
       <td>8.00|8.00<br>-<br>x<br>-</td>
@@ -811,7 +811,7 @@
       <td>8.25|8.25<br>x<br>x<br>-</td>
       <td>7.75|7.75<br>-<br>-<br>-</td>
       <td>8.25|8.25<br>-<br>x<br>-</td>
-      <td class="total-cell">158.50<br>7<br>9<br>0</td>
+      <td class="total-cell">31.70<br>7<br>9<br>0</td>
       <td>7.75|7.75<br>x<br>x<br>x</td>
       <td>7.75|7.75<br>-<br>x<br>x</td>
       <td>8.00|8.00<br>x<br>x<br>x</td>
@@ -822,7 +822,7 @@
       <td>8.00|8.00<br>x<br>x<br>x</td>
       <td>7.75|7.75<br>-<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x</td>
-      <td class="total-cell">158.00<br>7<br>10<br>10</td>
+      <td class="total-cell">31.60<br>7<br>10<br>10</td>
       <td>7.50|7.50<br>-<br>x<br>x</td>
       <td>7.50|7.50<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>-<br>x<br>x</td>
@@ -833,8 +833,8 @@
       <td>8.00|8.00<br>-<br>x<br>x</td>
       <td>7.75|7.75<br>-<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x</td>
-      <td class="total-cell">157.50<br>4<br>10<br>10</td>
-      <td class="total-cell">788.50<br>30<br>45<br>40</td>
+      <td class="total-cell">31.50<br>4<br>10<br>10</td>
+      <td class="total-cell">157.70<br>30<br>45<br>40</td>
     </tr>
     <tr>
       <td>13.</td>

--- a/tests/75-0607_wdsfworldopenstdadult/reconstructed_ergwert.html
+++ b/tests/75-0607_wdsfworldopenstdadult/reconstructed_ergwert.html
@@ -107,7 +107,7 @@
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
       <td>9.75|9.75<br>9.50|9.50<br>x<br>x<br>x</td>
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
-      <td class="total-cell">188.00<br>186.50<br>10<br>10<br>10</td>
+      <td class="total-cell">37.60<br>37.30<br>10<br>10<br>10</td>
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>-</td>
       <td>9.50|9.50<br>9.25|9.25<br>x<br>x<br>-</td>
       <td>9.50|9.75<br>9.50|9.50<br>x<br>x<br>-</td>
@@ -118,7 +118,7 @@
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>-</td>
       <td>9.75|9.75<br>9.75|9.75<br>x<br>x<br>-</td>
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>-</td>
-      <td class="total-cell">189.25<br>187.50<br>10<br>10<br>0</td>
+      <td class="total-cell">37.85<br>37.50<br>10<br>10<br>0</td>
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.00|9.00<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
@@ -129,7 +129,7 @@
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
       <td>9.00|9.00<br>9.25|9.25<br>x<br>x<br>x</td>
-      <td class="total-cell">187.50<br>186.00<br>10<br>10<br>10</td>
+      <td class="total-cell">37.50<br>37.20<br>10<br>10<br>10</td>
       <td>9.50|9.50<br>9.25|9.25<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.25|9.25<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
@@ -140,7 +140,7 @@
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
       <td>9.75|9.75<br>9.75|9.75<br>x<br>x<br>x</td>
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
-      <td class="total-cell">190.00<br>187.00<br>9<br>10<br>10</td>
+      <td class="total-cell">38.00<br>37.40<br>9<br>10<br>10</td>
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.25|9.25<br>x<br>x<br>x</td>
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
@@ -151,8 +151,8 @@
       <td>9.50|9.50<br>9.50|9.50<br>x<br>x<br>x</td>
       <td>9.75|9.75<br>9.75|9.75<br>x<br>x<br>x</td>
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
-      <td class="total-cell">189.00<br>187.50<br>10<br>10<br>10</td>
-      <td class="total-cell">943.75<br>934.50<br>49<br>50<br>40</td>
+      <td class="total-cell">37.80<br>37.50<br>10<br>10<br>10</td>
+      <td class="total-cell">188.75<br>186.90<br>49<br>50<br>40</td>
     </tr>
     <tr>
       <td>2.</td>
@@ -169,7 +169,7 @@
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
-      <td class="total-cell">177.50<br>177.50<br>10<br>10<br>10</td>
+      <td class="total-cell">35.50<br>35.50<br>10<br>10<br>10</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
       <td>9.00|9.00<br>8.50|8.50<br>x<br>x<br>-</td>
       <td>9.00|9.25<br>9.25|9.25<br>x<br>x<br>-</td>
@@ -180,7 +180,7 @@
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>-</td>
       <td>8.50|8.75<br>8.50|8.50<br>x<br>x<br>-</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
-      <td class="total-cell">177.75<br>176.50<br>10<br>10<br>0</td>
+      <td class="total-cell">35.55<br>35.30<br>10<br>10<br>0</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
       <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
@@ -191,7 +191,7 @@
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
-      <td class="total-cell">177.00<br>176.00<br>10<br>10<br>10</td>
+      <td class="total-cell">35.40<br>35.20<br>10<br>10<br>10</td>
       <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>-</td>
       <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
@@ -202,7 +202,7 @@
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
-      <td class="total-cell">179.50<br>177.50<br>10<br>10<br>9</td>
+      <td class="total-cell">35.90<br>35.50<br>10<br>10<br>9</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
@@ -213,8 +213,8 @@
       <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
-      <td class="total-cell">176.00<br>175.50<br>10<br>10<br>10</td>
-      <td class="total-cell">887.75<br>883.00<br>50<br>50<br>39</td>
+      <td class="total-cell">35.20<br>35.10<br>10<br>10<br>10</td>
+      <td class="total-cell">177.55<br>176.60<br>50<br>50<br>39</td>
     </tr>
     <tr>
       <td>3.</td>
@@ -231,7 +231,7 @@
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
       <td>8.75|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.50|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
-      <td class="total-cell">174.75<br>174.00<br>10<br>10<br>10</td>
+      <td class="total-cell">34.95<br>34.80<br>10<br>10<br>10</td>
       <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>-</td>
       <td>8.50|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
       <td>9.00|8.75<br>9.00|9.00<br>x<br>x<br>-</td>
@@ -242,7 +242,7 @@
       <td>9.00|9.00<br>9.25|9.25<br>x<br>x<br>-</td>
       <td>8.75|8.50<br>8.75|8.75<br>x<br>x<br>-</td>
       <td>8.50|8.75<br>8.75|8.75<br>x<br>x<br>-</td>
-      <td class="total-cell">173.25<br>175.50<br>10<br>10<br>0</td>
+      <td class="total-cell">34.65<br>35.10<br>10<br>10<br>0</td>
       <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>9.00|9.00<br>8.50|8.50<br>x<br>x<br>x</td>
       <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
@@ -253,7 +253,7 @@
       <td>9.25|9.25<br>9.25|9.25<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x</td>
-      <td class="total-cell">175.50<br>174.50<br>10<br>10<br>10</td>
+      <td class="total-cell">35.10<br>34.90<br>10<br>10<br>10</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>9.00|9.00<br>9.25|9.25<br>x<br>x<br>x</td>
@@ -264,7 +264,7 @@
       <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
-      <td class="total-cell">174.50<br>175.50<br>10<br>10<br>10</td>
+      <td class="total-cell">34.90<br>35.10<br>10<br>10<br>10</td>
       <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>9.00|9.00<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>9.00|9.00<br>9.00|9.00<br>x<br>x<br>x</td>
@@ -275,8 +275,8 @@
       <td>9.25|9.25<br>9.00|9.00<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x</td>
-      <td class="total-cell">176.00<br>175.00<br>10<br>9<br>10</td>
-      <td class="total-cell">874.00<br>874.50<br>50<br>49<br>40</td>
+      <td class="total-cell">35.20<br>35.00<br>10<br>9<br>10</td>
+      <td class="total-cell">174.80<br>174.90<br>50<br>49<br>40</td>
     </tr>
     <tr>
       <td>4.</td>
@@ -293,7 +293,7 @@
       <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">166.25<br>166.00<br>10<br>10<br>10<br>10</td>
+      <td class="total-cell">33.25<br>33.20<br>10<br>10<br>10<br>10</td>
       <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>-<br>x</td>
       <td>8.50|8.75<br>8.50|8.50<br>x<br>x<br>-<br>x</td>
       <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>-<br>x</td>
@@ -304,7 +304,7 @@
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>-<br>x</td>
       <td>8.25|8.00<br>7.75|7.75<br>x<br>x<br>-<br>x</td>
       <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>-<br>x</td>
-      <td class="total-cell">167.00<br>165.00<br>8<br>10<br>0<br>10</td>
+      <td class="total-cell">33.40<br>33.00<br>8<br>10<br>0<br>10</td>
       <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x<br>-</td>
       <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x<br>-</td>
       <td>8.50|8.50<br>8.25|8.25<br>-<br>x<br>x<br>-</td>
@@ -315,7 +315,7 @@
       <td>8.75|8.75<br>8.75|8.75<br>x<br>x<br>x<br>-</td>
       <td>7.75|7.75<br>7.75|7.75<br>-<br>x<br>x<br>-</td>
       <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>x<br>-</td>
-      <td class="total-cell">166.00<br>167.00<br>8<br>10<br>10<br>0</td>
+      <td class="total-cell">33.20<br>33.40<br>8<br>10<br>10<br>0</td>
       <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x<br>-</td>
@@ -326,7 +326,7 @@
       <td>9.00|9.00<br>8.50|8.50<br>x<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">168.00<br>166.50<br>10<br>10<br>8<br>9</td>
+      <td class="total-cell">33.60<br>33.30<br>10<br>10<br>8<br>9</td>
       <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x<br>x</td>
       <td>8.75|8.75<br>8.25|8.25<br>x<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>8.25|8.25<br>-<br>x<br>x<br>x</td>
@@ -337,8 +337,8 @@
       <td>8.75|8.75<br>8.50|8.50<br>x<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>7.50|7.50<br>x<br>-<br>x<br>x</td>
       <td>8.50|8.50<br>8.50|8.50<br>-<br>x<br>x<br>x</td>
-      <td class="total-cell">167.50<br>164.00<br>8<br>9<br>10<br>10</td>
-      <td class="total-cell">834.75<br>828.50<br>44<br>49<br>38<br>39</td>
+      <td class="total-cell">33.50<br>32.80<br>8<br>9<br>10<br>10</td>
+      <td class="total-cell">166.95<br>165.70<br>44<br>49<br>38<br>39</td>
     </tr>
     <tr>
       <td>5.</td>
@@ -355,7 +355,7 @@
       <td>8.25|8.00<br>8.25|8.25<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>8.25|8.25<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
-      <td class="total-cell">165.50<br>163.50<br>10<br>10<br>10</td>
+      <td class="total-cell">33.10<br>32.70<br>10<br>10<br>10</td>
       <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>-</td>
       <td>8.50|8.50<br>8.25|8.25<br>x<br>x<br>-</td>
       <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>-</td>
@@ -366,7 +366,7 @@
       <td>8.25|8.25<br>8.25|8.25<br>-<br>x<br>-</td>
       <td>8.50|8.50<br>8.25|8.25<br>x<br>x<br>-</td>
       <td>8.50|8.50<br>8.25|8.25<br>-<br>x<br>-</td>
-      <td class="total-cell">167.75<br>163.50<br>7<br>9<br>0</td>
+      <td class="total-cell">33.55<br>32.70<br>7<br>9<br>0</td>
       <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
@@ -377,7 +377,7 @@
       <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>8.00|8.00<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
-      <td class="total-cell">165.00<br>162.00<br>10<br>10<br>10</td>
+      <td class="total-cell">33.00<br>32.40<br>10<br>10<br>10</td>
       <td>8.00|8.00<br>7.75|7.75<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>8.25|8.25<br>x<br>x<br>x</td>
@@ -388,7 +388,7 @@
       <td>8.25|8.25<br>8.25|8.25<br>-<br>x<br>x</td>
       <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>8.50|8.50<br>x<br>x<br>x</td>
-      <td class="total-cell">165.00<br>163.50<br>9<br>9<br>10</td>
+      <td class="total-cell">33.00<br>32.70<br>9<br>9<br>10</td>
       <td>8.00|8.00<br>7.75|7.75<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>8.50|8.50<br>-<br>x<br>x</td>
@@ -399,8 +399,8 @@
       <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>8.25|8.25<br>x<br>x<br>x</td>
-      <td class="total-cell">165.00<br>163.00<br>9<br>10<br>10</td>
-      <td class="total-cell">828.25<br>815.50<br>45<br>48<br>40</td>
+      <td class="total-cell">33.00<br>32.60<br>9<br>10<br>10</td>
+      <td class="total-cell">165.65<br>163.10<br>45<br>48<br>40</td>
     </tr>
     <tr>
       <td>6.</td>
@@ -417,7 +417,7 @@
       <td>8.25|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
       <td>8.25|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
-      <td class="total-cell">165.00<br>164.50<br>10<br>10<br>10</td>
+      <td class="total-cell">33.00<br>32.90<br>10<br>10<br>10</td>
       <td>8.00|8.25<br>8.25|8.25<br>x<br>x<br>-</td>
       <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>-</td>
       <td>7.75|8.00<br>8.00|8.00<br>-<br>x<br>-</td>
@@ -428,7 +428,7 @@
       <td>8.50|8.50<br>8.75|8.75<br>x<br>x<br>-</td>
       <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>-</td>
       <td>8.25|8.50<br>8.25|8.25<br>x<br>x<br>-</td>
-      <td class="total-cell">164.75<br>164.00<br>9<br>10<br>0</td>
+      <td class="total-cell">32.95<br>32.80<br>9<br>10<br>0</td>
       <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>8.00|8.00<br>x<br>x<br>x</td>
@@ -439,7 +439,7 @@
       <td>8.50|8.50<br>9.00|9.00<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>8.25|8.25<br>-<br>x<br>x</td>
       <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
-      <td class="total-cell">165.50<br>165.50<br>9<br>10<br>10</td>
+      <td class="total-cell">33.10<br>33.10<br>9<br>10<br>10</td>
       <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x</td>
@@ -450,7 +450,7 @@
       <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
-      <td class="total-cell">165.00<br>165.00<br>10<br>10<br>10</td>
+      <td class="total-cell">33.00<br>33.00<br>10<br>10<br>10</td>
       <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>8.00|8.00<br>x<br>x<br>x</td>
@@ -461,8 +461,8 @@
       <td>8.50|8.50<br>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>8.50|8.50<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>8.25|8.25<br>x<br>x<br>x</td>
-      <td class="total-cell">164.50<br>164.00<br>10<br>10<br>10</td>
-      <td class="total-cell">824.75<br>823.00<br>48<br>50<br>40</td>
+      <td class="total-cell">32.90<br>32.80<br>10<br>10<br>10</td>
+      <td class="total-cell">164.95<br>164.60<br>48<br>50<br>40</td>
     </tr>
     <tr>
       <td>7.</td>
@@ -479,7 +479,7 @@
       <td>8.50|8.50<br>x<br>x<br>x<br>x</td>
       <td>7.25|7.25<br>x<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">161.00<br>9<br>10<br>10<br>10</td>
+      <td class="total-cell">32.20<br>9<br>10<br>10<br>10</td>
       <td>8.50|8.50<br>x<br>x<br>-<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>-<br>x</td>
       <td>7.75|7.75<br>-<br>x<br>-<br>-</td>
@@ -490,7 +490,7 @@
       <td>8.50|8.50<br>x<br>x<br>-<br>x</td>
       <td>7.00|7.00<br>-<br>x<br>-<br>x</td>
       <td>8.25|8.25<br>x<br>-<br>-<br>x</td>
-      <td class="total-cell">161.00<br>7<br>9<br>0<br>8</td>
+      <td class="total-cell">32.20<br>7<br>9<br>0<br>8</td>
       <td>8.50|8.50<br>x<br>x<br>x<br>-</td>
       <td>8.25|8.25<br>x<br>x<br>x<br>-</td>
       <td>7.75|7.75<br>-<br>x<br>x<br>-</td>
@@ -501,7 +501,7 @@
       <td>8.25|8.25<br>x<br>x<br>x<br>-</td>
       <td>7.25|7.25<br>-<br>x<br>x<br>-</td>
       <td>8.50|8.50<br>x<br>x<br>x<br>-</td>
-      <td class="total-cell">161.00<br>8<br>10<br>10<br>0</td>
+      <td class="total-cell">32.20<br>8<br>10<br>10<br>0</td>
       <td>8.50|8.50<br>x<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
@@ -512,7 +512,7 @@
       <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
       <td>6.25|6.25<br>-<br>-<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">159.50<br>9<br>9<br>10<br>9</td>
+      <td class="total-cell">31.90<br>9<br>9<br>10<br>9</td>
       <td>8.50|8.50<br>x<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x<br>-</td>
       <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
@@ -523,8 +523,8 @@
       <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
       <td>7.50|7.50<br>-<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">161.50<br>8<br>10<br>10<br>9</td>
-      <td class="total-cell">804.00<br>41<br>48<br>40<br>36</td>
+      <td class="total-cell">32.30<br>8<br>10<br>10<br>9</td>
+      <td class="total-cell">160.80<br>41<br>48<br>40<br>36</td>
     </tr>
     <tr>
       <td>8.</td>
@@ -541,7 +541,7 @@
       <td>8.25|8.25<br>x<br>x<br>x</td>
       <td>7.25|7.25<br>-<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x</td>
-      <td class="total-cell">157.00<br>9<br>10<br>10</td>
+      <td class="total-cell">31.40<br>9<br>10<br>10</td>
       <td>7.25|7.25<br>x<br>x<br>-</td>
       <td>8.25|8.25<br>x<br>x<br>-</td>
       <td>8.50|8.50<br>x<br>x<br>-</td>
@@ -552,7 +552,7 @@
       <td>8.25|8.25<br>x<br>x<br>-</td>
       <td>7.50|7.50<br>x<br>x<br>-</td>
       <td>8.25|8.25<br>x<br>x<br>-</td>
-      <td class="total-cell">158.50<br>9<br>10<br>0</td>
+      <td class="total-cell">31.70<br>9<br>10<br>0</td>
       <td>7.50|7.50<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
@@ -563,7 +563,7 @@
       <td>8.00|8.00<br>x<br>x<br>x</td>
       <td>7.25|7.25<br>-<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x</td>
-      <td class="total-cell">157.50<br>8<br>10<br>10</td>
+      <td class="total-cell">31.50<br>8<br>10<br>10</td>
       <td>7.25|7.25<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
@@ -574,7 +574,7 @@
       <td>8.00|8.00<br>x<br>x<br>x</td>
       <td>7.25|7.25<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>-<br>x<br>x</td>
-      <td class="total-cell">156.50<br>9<br>10<br>10</td>
+      <td class="total-cell">31.30<br>9<br>10<br>10</td>
       <td>7.25|7.25<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>x<br>x<br>x</td>
       <td>8.50|8.50<br>x<br>x<br>x</td>
@@ -585,8 +585,8 @@
       <td>8.00|8.00<br>x<br>x<br>x</td>
       <td>7.50|7.50<br>-<br>x<br>x</td>
       <td>8.00|8.00<br>x<br>x<br>x</td>
-      <td class="total-cell">157.50<br>8<br>10<br>9</td>
-      <td class="total-cell">787.00<br>43<br>50<br>39</td>
+      <td class="total-cell">31.50<br>8<br>10<br>9</td>
+      <td class="total-cell">157.40<br>43<br>50<br>39</td>
     </tr>
     <tr>
       <td>9.</td>
@@ -603,7 +603,7 @@
       <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
       <td>7.50|7.50<br>x<br>x<br>x<br>x</td>
       <td>7.50|7.50<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">151.00<br>5<br>10<br>9<br>10</td>
+      <td class="total-cell">30.20<br>5<br>10<br>9<br>10</td>
       <td>7.25|7.25<br>-<br>x<br>-<br>x</td>
       <td>7.75|7.75<br>-<br>x<br>-<br>x</td>
       <td>8.00|8.00<br>x<br>x<br>-<br>x</td>
@@ -614,7 +614,7 @@
       <td>8.00|8.00<br>x<br>x<br>-<br>x</td>
       <td>7.75|7.75<br>x<br>-<br>-<br>x</td>
       <td>7.25|7.25<br>x<br>x<br>-<br>x</td>
-      <td class="total-cell">153.00<br>6<br>9<br>0<br>10</td>
+      <td class="total-cell">30.60<br>6<br>9<br>0<br>10</td>
       <td>7.25|7.25<br>x<br>x<br>x<br>-</td>
       <td>7.75|7.75<br>-<br>x<br>x<br>-</td>
       <td>8.00|8.00<br>x<br>x<br>x<br>-</td>
@@ -625,7 +625,7 @@
       <td>8.00|8.00<br>x<br>x<br>x<br>-</td>
       <td>7.50|7.50<br>x<br>x<br>x<br>-</td>
       <td>7.25|7.25<br>-<br>x<br>x<br>-</td>
-      <td class="total-cell">151.50<br>4<br>9<br>10<br>0</td>
+      <td class="total-cell">30.30<br>4<br>9<br>10<br>0</td>
       <td>7.25|7.25<br>-<br>x<br>x<br>x</td>
       <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
@@ -636,7 +636,7 @@
       <td>8.00|8.00<br>-<br>x<br>x<br>x</td>
       <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
       <td>7.25|7.25<br>-<br>x<br>x<br>x</td>
-      <td class="total-cell">152.50<br>5<br>10<br>9<br>10</td>
+      <td class="total-cell">30.50<br>5<br>10<br>9<br>10</td>
       <td>7.00|7.00<br>-<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x<br>x</td>
@@ -647,8 +647,8 @@
       <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
       <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
       <td>7.50|7.50<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">153.50<br>7<br>9<br>10<br>10</td>
-      <td class="total-cell">761.50<br>27<br>47<br>38<br>40</td>
+      <td class="total-cell">30.70<br>7<br>9<br>10<br>10</td>
+      <td class="total-cell">152.30<br>27<br>47<br>38<br>40</td>
     </tr>
     <tr>
       <td>10.</td>
@@ -665,7 +665,7 @@
       <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
       <td>7.50|7.50<br>-<br>x<br>x<br>x</td>
       <td>7.50|7.50<br>-<br>x<br>x<br>x</td>
-      <td class="total-cell">151.50<br>7<br>10<br>10<br>10</td>
+      <td class="total-cell">30.30<br>7<br>10<br>10<br>10</td>
       <td>7.00|7.00<br>x<br>x<br>-<br>x</td>
       <td>7.75|7.75<br>x<br>x<br>-<br>x</td>
       <td>7.50|7.50<br>-<br>x<br>-<br>x</td>
@@ -676,7 +676,7 @@
       <td>8.00|8.00<br>x<br>x<br>-<br>x</td>
       <td>7.00|7.00<br>-<br>x<br>-<br>x</td>
       <td>7.50|7.50<br>x<br>x<br>-<br>x</td>
-      <td class="total-cell">151.50<br>7<br>9<br>0<br>9</td>
+      <td class="total-cell">30.30<br>7<br>9<br>0<br>9</td>
       <td>7.25|7.25<br>x<br>x<br>x<br>-</td>
       <td>8.00|8.00<br>x<br>x<br>x<br>-</td>
       <td>7.50|7.50<br>-<br>x<br>x<br>-</td>
@@ -687,7 +687,7 @@
       <td>8.00|8.00<br>x<br>x<br>-<br>-</td>
       <td>7.50|7.50<br>x<br>x<br>x<br>-</td>
       <td>7.25|7.25<br>-<br>x<br>x<br>-</td>
-      <td class="total-cell">153.50<br>6<br>10<br>9<br>0</td>
+      <td class="total-cell">30.70<br>6<br>10<br>9<br>0</td>
       <td>7.25|7.25<br>x<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>x<br>x<br>x<br>x</td>
       <td>7.50|7.50<br>-<br>-<br>x<br>x</td>
@@ -698,7 +698,7 @@
       <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
       <td>7.50|7.50<br>x<br>-<br>x<br>x</td>
       <td>7.25|7.25<br>-<br>x<br>x<br>x</td>
-      <td class="total-cell">152.00<br>6<br>6<br>10<br>10</td>
+      <td class="total-cell">30.40<br>6<br>6<br>10<br>10</td>
       <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
       <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
       <td>7.50|7.50<br>-<br>x<br>x<br>x</td>
@@ -709,8 +709,8 @@
       <td>7.75|7.75<br>-<br>x<br>x<br>x</td>
       <td>7.00|7.00<br>-<br>x<br>x<br>x</td>
       <td>7.25|7.25<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">150.00<br>5<br>10<br>10<br>10</td>
-      <td class="total-cell">758.50<br>31<br>45<br>39<br>39</td>
+      <td class="total-cell">30.00<br>5<br>10<br>10<br>10</td>
+      <td class="total-cell">151.70<br>31<br>45<br>39<br>39</td>
     </tr>
     <tr>
       <td>11.</td>
@@ -727,7 +727,7 @@
       <td>8.00|8.00<br>x<br>x<br>x</td>
       <td>8.25|8.25<br>x<br>x<br>x</td>
       <td>7.25|7.25<br>-<br>x<br>x</td>
-      <td class="total-cell">151.50<br>4<br>10<br>10</td>
+      <td class="total-cell">30.30<br>4<br>10<br>10</td>
       <td>7.00|7.00<br>-<br>x<br>-</td>
       <td>7.75|7.75<br>-<br>x<br>-</td>
       <td>7.75|7.75<br>x<br>x<br>-</td>
@@ -738,7 +738,7 @@
       <td>7.75|7.75<br>x<br>x<br>-</td>
       <td>8.00|8.00<br>x<br>x<br>-</td>
       <td>7.50|7.50<br>-<br>x<br>-</td>
-      <td class="total-cell">151.00<br>6<br>9<br>0</td>
+      <td class="total-cell">30.20<br>6<br>9<br>0</td>
       <td>7.00|7.00<br>-<br>x<br>x</td>
       <td>7.75|7.75<br>-<br>x<br>x</td>
       <td>7.75|7.75<br>x<br>x<br>x</td>
@@ -749,7 +749,7 @@
       <td>7.75|7.75<br>-<br>x<br>x</td>
       <td>8.00|8.00<br>x<br>x<br>x</td>
       <td>7.00|7.00<br>x<br>x<br>x</td>
-      <td class="total-cell">150.50<br>6<br>10<br>10</td>
+      <td class="total-cell">30.10<br>6<br>10<br>10</td>
       <td>7.00|7.00<br>-<br>x<br>x</td>
       <td>7.75|7.75<br>-<br>x<br>x</td>
       <td>7.75|7.75<br>x<br>x<br>x</td>
@@ -760,7 +760,7 @@
       <td>7.75|7.75<br>x<br>x<br>x</td>
       <td>7.75|7.75<br>x<br>x<br>x</td>
       <td>7.00|7.00<br>x<br>x<br>x</td>
-      <td class="total-cell">150.50<br>6<br>10<br>9</td>
+      <td class="total-cell">30.10<br>6<br>10<br>9</td>
       <td>7.00|7.00<br>x<br>x<br>x</td>
       <td>7.75|7.75<br>x<br>-<br>x</td>
       <td>7.75|7.75<br>-<br>x<br>x</td>
@@ -771,8 +771,8 @@
       <td>7.50|7.50<br>x<br>x<br>x</td>
       <td>7.75|7.75<br>-<br>x<br>x</td>
       <td>7.25|7.25<br>-<br>x<br>x</td>
-      <td class="total-cell">150.00<br>6<br>9<br>9</td>
-      <td class="total-cell">753.50<br>28<br>48<br>38</td>
+      <td class="total-cell">30.00<br>6<br>9<br>9</td>
+      <td class="total-cell">150.70<br>28<br>48<br>38</td>
     </tr>
     <tr>
       <td>12.</td>
@@ -789,7 +789,7 @@
       <td>7.50|7.50<br>x<br>x<br>x<br>x</td>
       <td>7.00|7.00<br>-<br>x<br>x<br>x</td>
       <td>7.50|7.50<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">149.00<br>7<br>10<br>10<br>10</td>
+      <td class="total-cell">29.80<br>7<br>10<br>10<br>10</td>
       <td>7.00|7.00<br>-<br>x<br>-<br>x</td>
       <td>7.50|7.50<br>-<br>x<br>-<br>x</td>
       <td>7.75|7.75<br>x<br>x<br>-<br>x</td>
@@ -800,7 +800,7 @@
       <td>8.00|8.00<br>x<br>x<br>-<br>x</td>
       <td>7.00|7.00<br>-<br>x<br>-<br>x</td>
       <td>7.50|7.50<br>x<br>x<br>-<br>x</td>
-      <td class="total-cell">151.00<br>7<br>10<br>0<br>10</td>
+      <td class="total-cell">30.20<br>7<br>10<br>0<br>10</td>
       <td>7.00|7.00<br>-<br>x<br>x<br>-</td>
       <td>7.50|7.50<br>-<br>x<br>-<br>-</td>
       <td>7.75|7.75<br>-<br>x<br>x<br>-</td>
@@ -811,7 +811,7 @@
       <td>8.00|8.00<br>x<br>x<br>x<br>-</td>
       <td>7.00|7.00<br>-<br>-<br>x<br>-</td>
       <td>7.25|7.25<br>-<br>x<br>-<br>-</td>
-      <td class="total-cell">151.00<br>5<br>9<br>8<br>0</td>
+      <td class="total-cell">30.20<br>5<br>9<br>8<br>0</td>
       <td>7.00|7.00<br>-<br>x<br>x<br>x</td>
       <td>7.50|7.50<br>-<br>x<br>x<br>x</td>
       <td>7.50|7.50<br>-<br>x<br>x<br>x</td>
@@ -822,7 +822,7 @@
       <td>7.75|7.75<br>x<br>x<br>x<br>x</td>
       <td>7.00|7.00<br>-<br>x<br>x<br>x</td>
       <td>7.25|7.25<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">149.50<br>5<br>10<br>9<br>10</td>
+      <td class="total-cell">29.90<br>5<br>10<br>9<br>10</td>
       <td>7.00|7.00<br>-<br>x<br>x<br>x</td>
       <td>8.00|8.00<br>-<br>x<br>x<br>x</td>
       <td>7.75|7.75<br>x<br>-<br>x<br>x</td>
@@ -833,8 +833,8 @@
       <td>8.00|8.00<br>x<br>x<br>x<br>-</td>
       <td>7.25|7.25<br>-<br>x<br>x<br>x</td>
       <td>7.50|7.50<br>x<br>x<br>x<br>x</td>
-      <td class="total-cell">152.50<br>6<br>9<br>9<br>9</td>
-      <td class="total-cell">753.00<br>30<br>48<br>36<br>39</td>
+      <td class="total-cell">30.50<br>6<br>9<br>9<br>9</td>
+      <td class="total-cell">150.60<br>30<br>48<br>36<br>39</td>
     </tr>
     <tr>
       <td>13.</td>


### PR DESCRIPTION
The WDSF summarization logic was incorrect. Previously, it was summing all judge totals. Per the requirements, the score for each dance should be the sum of the average value per category (Technical Quality, Movement to Music, Partnering Skills, and Choreography).

This PR:
1. Implements `calculate_wdsf_dance_score` in `src/models/skating.rs` to correctly compute category averages and their sum.
2. Updates `verify_wdsf_score` to strictly check that a single judge's total is the sum of components.
3. Updates `src/sources/html_gen.rs` to use the new summarization logic for both dance totals and round totals in WDSF rounds.
4. Updates integration test golden files and artifacts.

---
*PR created automatically by Jules for task [13622140051701702910](https://jules.google.com/task/13622140051701702910) started by @phyk*